### PR TITLE
ci: add project automation workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -55,7 +55,7 @@ jobs:
           # Find project item ID via the issue's own projectItems
           # (avoids pagination and cross-repo number collision)
           ITEM_ID=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!, $issue: Int!, $project_id: ID!) {
+            query($owner: String!, $repo: String!, $issue: Int!) {
               repository(owner: $owner, name: $repo) {
                 issue(number: $issue) {
                   projectItems(first: 20) {
@@ -70,7 +70,6 @@ jobs:
             -f owner=ricemonkeys \
             -f repo=codetrace \
             -F issue=$ISSUE_NUM \
-            -f project_id="$PROJECT_ID" \
             --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
 
           if [ -z "$ITEM_ID" ]; then

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,99 @@
+name: Project Automation
+
+on:
+  pull_request:
+    types: [opened, closed]
+
+permissions:
+  contents: read
+
+jobs:
+  update-project-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get linked issue number
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          ISSUE=$(echo "$PR_BODY" | grep -oP '(?i)closes?\s+#\K[0-9]+' | head -1)
+          echo "number=${ISSUE}" >> $GITHUB_OUTPUT
+          echo "Linked issue: ${ISSUE}"
+
+      - name: Move linked issue on project board
+        if: steps.issue.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PROJECT_ID: PVT_kwDOELBNFs4BWNHQ
+          FIELD_ID: PVTSSF_lADOELBNFs4BWNHQzhRjQUY
+          OPT_IN_PROGRESS: 47fc9ee4
+          OPT_IN_REVIEW: aba860b9
+          OPT_DONE: 98236657
+          OPT_BACKLOG: f75ad846
+        run: |
+          EVENT="${{ github.event.action }}"
+          MERGED="${{ github.event.pull_request.merged }}"
+          ISSUE_NUM="${{ steps.issue.outputs.number }}"
+          REPO="${{ github.repository }}"
+
+          # Determine target status
+          if [ "$EVENT" = "opened" ]; then
+            TARGET_OPT="$OPT_IN_REVIEW"
+            LABEL="In review"
+          elif [ "$EVENT" = "closed" ] && [ "$MERGED" = "true" ]; then
+            TARGET_OPT="$OPT_DONE"
+            LABEL="Done"
+          elif [ "$EVENT" = "closed" ] && [ "$MERGED" = "false" ]; then
+            TARGET_OPT="$OPT_BACKLOG"
+            LABEL="Backlog"
+          else
+            echo "No status change needed for event: $EVENT"
+            exit 0
+          fi
+
+          # Find project item ID for the linked issue
+          ITEM_ID=$(gh api graphql -f query='
+            query($org: String!, $num: Int!, $issue: Int!) {
+              organization(login: $org) {
+                projectV2(number: $num) {
+                  items(first: 50) {
+                    nodes {
+                      id
+                      content {
+                        ... on Issue { number }
+                      }
+                    }
+                  }
+                }
+              }
+            }' \
+            -f org=ricemonkeys \
+            -F num=3 \
+            -F issue=$ISSUE_NUM \
+            --jq ".data.organization.projectV2.items.nodes[] | select(.content.number == $ISSUE_NUM) | .id")
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue #$ISSUE_NUM not found in project — skipping"
+            exit 0
+          fi
+
+          echo "Moving issue #$ISSUE_NUM (item: $ITEM_ID) → $LABEL"
+
+          gh api graphql -f query='
+            mutation($project: ID!, $item: ID!, $field: ID!, $value: String!) {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: $project
+                itemId: $item
+                fieldId: $field
+                value: { singleSelectOptionId: $value }
+              }) {
+                projectV2Item { id }
+              }
+            }' \
+            -f project="$PROJECT_ID" \
+            -f item="$ITEM_ID" \
+            -f field="$FIELD_ID" \
+            -f value="$TARGET_OPT"
+
+          echo "Done: issue #$ISSUE_NUM → $LABEL"

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -52,26 +52,26 @@ jobs:
             exit 0
           fi
 
-          # Find project item ID for the linked issue
+          # Find project item ID via the issue's own projectItems
+          # (avoids pagination and cross-repo number collision)
           ITEM_ID=$(gh api graphql -f query='
-            query($org: String!, $num: Int!, $issue: Int!) {
-              organization(login: $org) {
-                projectV2(number: $num) {
-                  items(first: 50) {
+            query($owner: String!, $repo: String!, $issue: Int!, $project_id: ID!) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $issue) {
+                  projectItems(first: 20) {
                     nodes {
                       id
-                      content {
-                        ... on Issue { number }
-                      }
+                      project { id }
                     }
                   }
                 }
               }
             }' \
-            -f org=ricemonkeys \
-            -F num=3 \
+            -f owner=ricemonkeys \
+            -f repo=codetrace \
             -F issue=$ISSUE_NUM \
-            --jq ".data.organization.projectV2.items.nodes[] | select(.content.number == $ISSUE_NUM) | .id")
+            -f project_id="$PROJECT_ID" \
+            --jq ".data.repository.issue.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
 
           if [ -z "$ITEM_ID" ]; then
             echo "Issue #$ISSUE_NUM not found in project — skipping"


### PR DESCRIPTION
## Summary

- PR 오픈 시 연결된 이슈를 자동으로 **In review**로 이동
- PR 머지 시 **Done**으로 이동
- PR 닫힘(머지 없이) 시 **Backlog**으로 복귀
- In progress는 브랜치 생성 시 담당자가 수동으로 이동

## 사전 설정 필요

워크플로우 실행 전 아래 시크릿 등록 필요:

`ricemonkeys` org Settings → Secrets and variables → Actions → **New secret**
- Name: `PROJECT_TOKEN`
- Value: GitHub PAT (`project` 스코프 포함)

## Test plan

- [ ] `PROJECT_TOKEN` 시크릿 등록
- [ ] 테스트 PR 오픈 → 연결 이슈가 In review로 이동하는지 확인
- [ ] PR 머지 → Done으로 이동하는지 확인