### PR TITLE
[codex] feat(local-storage): persist codetrace canvas files

### DIFF
--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -27,7 +27,17 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       ],
     };
 
-    webviewPanel.webview.html = await this._getHtml(webviewPanel.webview, document.getText());
+    try {
+      webviewPanel.webview.html = await this._getHtml(webviewPanel.webview, document.getText());
+    } catch (error) {
+      console.error('CodeTrace: failed to load webview assets', error);
+      webviewPanel.webview.html = this._getFallbackHtml(
+        'CodeTrace webview build is missing. Run npm run build --workspace=frontend and reopen this file.',
+      );
+      vscode.window.showErrorMessage(
+        'CodeTrace: webview build is missing. Run npm run build --workspace=frontend.',
+      );
+    }
 
     // document → webview
     const pushContent = () => {
@@ -123,10 +133,63 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
   private _rewriteWebviewUris(html: string, webview: vscode.Webview): string {
     const webviewRoot = vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'webview');
 
-    return html.replace(/\b(src|href)="\/([^"]+)"/g, (_match, attribute: string, resourcePath: string) => {
-      const resourceUri = vscode.Uri.joinPath(webviewRoot, ...resourcePath.split('/'));
+    return html.replace(/\b(src|href)="([^"]+)"/g, (_match, attribute: string, resourcePath: string) => {
+      if (this._isExternalResource(resourcePath)) {
+        return `${attribute}="${resourcePath}"`;
+      }
+
+      const normalizedPath = resourcePath.replace(/^\.?\//, '').replace(/^\/+/, '');
+      if (!normalizedPath || normalizedPath.startsWith('..')) {
+        return `${attribute}="${resourcePath}"`;
+      }
+
+      const resourceUri = vscode.Uri.joinPath(webviewRoot, ...normalizedPath.split('/'));
       return `${attribute}="${webview.asWebviewUri(resourceUri)}"`;
     });
+  }
+
+  private _getFallbackHtml(message: string): string {
+    const csp = [
+      `default-src 'none'`,
+      `style-src 'unsafe-inline'`,
+    ].join('; ');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="${csp}" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CodeTrace Canvas</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: grid; place-items: center; font-family: system-ui, sans-serif; color: #1f2937; background: #f9fafb; }
+    main { max-width: 520px; padding: 24px; }
+    h1 { margin: 0 0 12px; font-size: 20px; }
+    p { margin: 0; line-height: 1.5; }
+    code { display: inline-block; margin-top: 16px; padding: 4px 6px; border-radius: 4px; background: #eef2ff; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>CodeTrace Canvas</h1>
+    <p>${this._escapeHtml(message)}</p>
+    <code>npm run build --workspace=frontend</code>
+  </main>
+</body>
+</html>`;
+  }
+
+  private _isExternalResource(resourcePath: string): boolean {
+    return /^(?:[a-z][a-z0-9+.-]*:|#|\/\/)/i.test(resourcePath);
+  }
+
+  private _escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
   private _scriptString(value: string): string {

--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -27,7 +27,7 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       ],
     };
 
-    webviewPanel.webview.html = this._getHtml(webviewPanel.webview);
+    webviewPanel.webview.html = await this._getHtml(webviewPanel.webview, document.getText());
 
     // document → webview
     const pushContent = () => {
@@ -43,58 +43,66 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       }
     });
 
-    webviewPanel.onDidDispose(() => changeSubscription.dispose());
-
     // webview → document
-    webviewPanel.webview.onDidReceiveMessage(msg => {
-      if (msg.type === 'save') {
-        this._updateDocument(document, msg.content);
+    const saveSubscription = webviewPanel.webview.onDidReceiveMessage(async msg => {
+      if (msg.type === 'save' && typeof msg.content === 'string') {
+        await this._updateDocument(document, msg.content);
+      } else if (msg.type === 'saveFile' && typeof msg.content === 'string') {
+        await this._updateDocument(document, msg.content);
+        await document.save();
       }
+    });
+
+    webviewPanel.onDidDispose(() => {
+      changeSubscription.dispose();
+      saveSubscription.dispose();
     });
 
     pushContent();
   }
 
-  private _updateDocument(document: vscode.TextDocument, content: string) {
+  private async _updateDocument(document: vscode.TextDocument, content: string) {
+    if (document.getText() === content) return;
+
     const edit = new vscode.WorkspaceEdit();
     edit.replace(
       document.uri,
       new vscode.Range(0, 0, document.lineCount, 0),
       content,
     );
-    vscode.workspace.applyEdit(edit);
+    await vscode.workspace.applyEdit(edit);
   }
 
-  private _getHtml(webview: vscode.Webview): string {
+  private async _getHtml(webview: vscode.Webview, initialContent: string): Promise<string> {
     const nonce = this._nonce();
     const csp = [
       `default-src 'none'`,
       `style-src ${webview.cspSource} 'unsafe-inline'`,
-      `script-src 'nonce-${nonce}'`,
+      `script-src ${webview.cspSource} 'nonce-${nonce}'`,
       `img-src ${webview.cspSource} data: blob:`,
       `font-src ${webview.cspSource}`,
     ].join('; ');
 
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta http-equiv="Content-Security-Policy" content="${csp}" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CodeTrace Canvas</title>
-  <style>
-    * { margin: 0; padding: 0; box-sizing: border-box; }
-    html, body, #root { width: 100%; height: 100vh; overflow: hidden; }
-  </style>
-</head>
-<body>
-  <div id="root"></div>
+    const indexUri = vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'webview', 'index.html');
+    const html = new TextDecoder().decode(await vscode.workspace.fs.readFile(indexUri));
+
+    return this._rewriteWebviewUris(html, webview)
+      .replace(
+        '<head>',
+        `<head>
+  <meta http-equiv="Content-Security-Policy" content="${csp}" />`,
+      )
+      .replace(/<script(\s)/g, `<script nonce="${nonce}"$1`)
+      .replace(
+        '<body>',
+        `<body>
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
+    window.__codetrace_initialContent = ${this._scriptString(initialContent)};
 
     window.addEventListener('message', event => {
-      const { type, content } = event.data;
-      if (type === 'update') {
+      const { type, content } = event.data ?? {};
+      if (type === 'update' && typeof content === 'string') {
         window.__codetrace_initialContent = content;
         if (window.__codetrace_onUpdate) window.__codetrace_onUpdate(content);
       }
@@ -103,9 +111,29 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     window.__codetrace_save = (content) => {
       vscode.postMessage({ type: 'save', content });
     };
+
+    window.__codetrace_saveFile = (content) => {
+      vscode.postMessage({ type: 'saveFile', content });
+    };
   </script>
-</body>
-</html>`;
+`,
+      );
+  }
+
+  private _rewriteWebviewUris(html: string, webview: vscode.Webview): string {
+    const webviewRoot = vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'webview');
+
+    return html.replace(/\b(src|href)="\/([^"]+)"/g, (_match, attribute: string, resourcePath: string) => {
+      const resourceUri = vscode.Uri.joinPath(webviewRoot, ...resourcePath.split('/'));
+      return `${attribute}="${webview.asWebviewUri(resourceUri)}"`;
+    });
+  }
+
+  private _scriptString(value: string): string {
+    return JSON.stringify(value)
+      .replace(/</g, '\\u003c')
+      .replace(/\u2028/g, '\\u2028')
+      .replace(/\u2029/g, '\\u2029');
   }
 
   private _nonce(): string {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -19,11 +19,11 @@ export function activate(context: vscode.ExtensionContext) {
       });
       if (!name) return;
 
-      const dir = vscode.Uri.joinPath(workspaceFolders[0].uri, '.codetrace');
+      const dir = vscode.Uri.joinPath(workspaceFolders[0].uri, '.codetrace', 'canvases');
       await vscode.workspace.fs.createDirectory(dir);
 
       const file = vscode.Uri.joinPath(dir, `${name.trim()}.codetrace`);
-      const initial = JSON.stringify({ version: 1, elements: [], cards: [], appState: {} }, null, 2);
+      const initial = `${JSON.stringify({ version: 1, elements: [], cards: [], appState: {} }, null, 2)}\n`;
       await vscode.workspace.fs.writeFile(file, new TextEncoder().encode(initial));
 
       await vscode.commands.executeCommand('vscode.openWith', file, CanvasEditorProvider.viewType);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,7 @@ export default function App() {
       appState: initialData.appState as unknown as AppState,
       commitToHistory: false,
     });
+    // Excalidraw may emit onChange after updateScene; suppress those document echoes on the next tick.
     window.setTimeout(() => {
       isApplyingDocumentRef.current = false;
     }, 0);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,118 @@
 import { Excalidraw } from '@excalidraw/excalidraw';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { ComponentProps } from 'react';
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/types/element/types';
+import type {
+  AppState,
+  BinaryFileData,
+  BinaryFiles,
+  ExcalidrawImperativeAPI,
+  ExcalidrawInitialDataState,
+} from '@excalidraw/excalidraw/types/types';
+import {
+  createCanvasDocumentFromScene,
+  parseCanvasDocumentContent,
+  toExcalidrawInitialData,
+} from './storage/canvasStorage';
+import { serializeCanvasDocument, type ExcalidrawElementStub } from './types/CanvasDocument';
+import type { CodeCard } from './types/CodeCard';
+import {
+  getInitialDocumentContent,
+  saveDocumentContent,
+  saveDocumentFile,
+  subscribeDocumentUpdates,
+} from './vscodeBridge';
+
+type ExcalidrawChangeHandler = NonNullable<ComponentProps<typeof Excalidraw>['onChange']>;
+
+function readInitialDocument() {
+  return parseCanvasDocumentContent(getInitialDocumentContent() ?? '');
+}
 
 export default function App() {
+  const initialDocument = useMemo(readInitialDocument, []);
+  const initialContent = useMemo(() => serializeCanvasDocument(initialDocument), [initialDocument]);
+  const initialData = useMemo(() => toExcalidrawInitialData(initialDocument), [initialDocument]);
+
+  const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
+  const cardsRef = useRef<CodeCard[]>([]);
+  const latestContentRef = useRef<string>(initialContent);
+  const isApplyingDocumentRef = useRef(false);
+
+  useEffect(() => {
+    cardsRef.current = initialDocument.cards;
+  }, [initialDocument]);
+
+  useEffect(() => {
+    const handleSaveShortcut = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
+        event.preventDefault();
+        saveDocumentFile(latestContentRef.current);
+      }
+    };
+
+    window.addEventListener('keydown', handleSaveShortcut);
+    return () => window.removeEventListener('keydown', handleSaveShortcut);
+  }, []);
+
+  const applyDocumentContent = useCallback((content: string) => {
+    const document = parseCanvasDocumentContent(content);
+    const initialData = toExcalidrawInitialData(document);
+    const api = apiRef.current;
+
+    cardsRef.current = document.cards;
+    latestContentRef.current = content;
+
+    if (!api) return;
+
+    isApplyingDocumentRef.current = true;
+    const files = Object.values(document.files ?? {}) as BinaryFileData[];
+    if (files.length > 0) {
+      api.addFiles(files);
+    }
+    api.updateScene({
+      elements: initialData.elements as unknown as ExcalidrawElement[],
+      appState: initialData.appState as unknown as AppState,
+      commitToHistory: false,
+    });
+    window.setTimeout(() => {
+      isApplyingDocumentRef.current = false;
+    }, 0);
+  }, []);
+
+  useEffect(() => subscribeDocumentUpdates(applyDocumentContent), [applyDocumentContent]);
+
+  const handleExcalidrawAPI = useCallback((api: ExcalidrawImperativeAPI) => {
+    apiRef.current = api;
+  }, []);
+
+  const handleChange = useCallback<ExcalidrawChangeHandler>(
+    (elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {
+      if (isApplyingDocumentRef.current) return;
+
+      const document = createCanvasDocumentFromScene({
+        elements: elements as unknown as ExcalidrawElementStub[],
+        appState: appState as unknown as Record<string, unknown>,
+        files: files as unknown as Record<string, unknown>,
+        cards: cardsRef.current,
+      });
+      const content = serializeCanvasDocument(document);
+
+      if (content === latestContentRef.current) return;
+
+      latestContentRef.current = content;
+      saveDocumentContent(content);
+    },
+    [],
+  );
+
   return (
     <div style={{ width: '100%', height: '100%' }}>
-      <Excalidraw />
+      <Excalidraw
+        excalidrawAPI={handleExcalidrawAPI}
+        initialData={initialData as unknown as ExcalidrawInitialDataState}
+        onChange={handleChange}
+      />
     </div>
   );
 }

--- a/frontend/src/storage/canvasStorage.test.ts
+++ b/frontend/src/storage/canvasStorage.test.ts
@@ -1,0 +1,73 @@
+import {
+  createCanvasDocumentFromScene,
+  parseCanvasDocumentContent,
+  toExcalidrawInitialData,
+} from './canvasStorage';
+import { serializeCanvasDocument } from '../types/CanvasDocument';
+import type { CodeCard } from '../types/CodeCard';
+
+const card: CodeCard = {
+  id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+  file: {
+    path: 'frontend/src/App.tsx',
+  },
+  range: {
+    startLine: 1,
+    endLine: 8,
+  },
+  snapshot: 'export default function App() {}',
+  language: 'typescriptreact',
+  customData: {},
+};
+
+describe('canvasStorage', () => {
+  it('parses blank content as an empty canvas document', () => {
+    expect(parseCanvasDocumentContent('')).toEqual({
+      version: 1,
+      elements: [],
+      cards: [],
+      appState: {},
+    });
+  });
+
+  it('creates a serializable canvas document from a scene snapshot', () => {
+    const document = createCanvasDocumentFromScene({
+      elements: [{ id: 'element-1', type: 'rectangle', x: 10 }],
+      appState: { viewBackgroundColor: '#ffffff' },
+      files: { fileId: { id: 'fileId', dataURL: 'data:image/png;base64,', mimeType: 'image/png' } },
+      cards: [card],
+    });
+
+    expect(document).toEqual({
+      version: 1,
+      elements: [{ id: 'element-1', type: 'rectangle', x: 10 }],
+      cards: [card],
+      appState: { viewBackgroundColor: '#ffffff' },
+      files: { fileId: { id: 'fileId', dataURL: 'data:image/png;base64,', mimeType: 'image/png' } },
+    });
+  });
+
+  it('round-trips through document serialization', () => {
+    const document = createCanvasDocumentFromScene({
+      elements: [{ id: 'element-1', type: 'text', text: 'hello' }],
+      appState: { gridSize: 20 },
+      cards: [card],
+    });
+
+    expect(parseCanvasDocumentContent(serializeCanvasDocument(document))).toEqual(document);
+  });
+
+  it('converts a canvas document into Excalidraw initial data', () => {
+    const document = createCanvasDocumentFromScene({
+      elements: [{ id: 'element-1', type: 'rectangle' }],
+      appState: { viewBackgroundColor: '#ffffff' },
+      cards: [],
+    });
+
+    expect(toExcalidrawInitialData(document)).toEqual({
+      elements: [{ id: 'element-1', type: 'rectangle' }],
+      appState: { viewBackgroundColor: '#ffffff' },
+      files: {},
+    });
+  });
+});

--- a/frontend/src/storage/canvasStorage.ts
+++ b/frontend/src/storage/canvasStorage.ts
@@ -1,10 +1,12 @@
 import {
   CANVAS_DOCUMENT_VERSION,
   type CanvasDocument,
+  type CanvasBinaryFile,
   type ExcalidrawElementStub,
   assertCanvasDocument,
   createEmptyCanvasDocument,
   deserializeCanvasDocument,
+  isCanvasBinaryFile,
   isExcalidrawElementStub,
 } from '../types/CanvasDocument';
 import type { CodeCard } from '../types/CodeCard';
@@ -20,7 +22,7 @@ export type CanvasSceneSnapshot = {
 export type ExcalidrawInitialDataSnapshot = {
   elements: readonly ExcalidrawElementStub[];
   appState: Record<string, unknown>;
-  files: Record<string, unknown>;
+  files: Record<string, CanvasBinaryFile>;
 };
 
 export function parseCanvasDocumentContent(content: string): CanvasDocument {
@@ -39,7 +41,7 @@ export function createCanvasDocumentFromScene(scene: CanvasSceneSnapshot): Canva
     appState: cloneRecord(scene.appState ?? {}),
   };
 
-  const files = cloneRecord(scene.files ?? {});
+  const files = cloneFiles(scene.files ?? {});
   if (Object.keys(files).length > 0) {
     document.files = files;
   }
@@ -66,6 +68,14 @@ function cloneElements(elements: readonly ExcalidrawElementStub[]): ExcalidrawEl
 function cloneRecord(value: Record<string, unknown>): Record<string, unknown> {
   const cloned = cloneJsonValue(value, {});
   return isRecord(cloned) ? cloned : {};
+}
+
+function cloneFiles(value: Record<string, unknown>): Record<string, CanvasBinaryFile> {
+  return Object.fromEntries(
+    Object.entries(cloneRecord(value)).filter((entry): entry is [string, CanvasBinaryFile] =>
+      isCanvasBinaryFile(entry[1]),
+    ),
+  );
 }
 
 function cloneJsonValue(value: unknown, fallback: unknown): unknown {

--- a/frontend/src/storage/canvasStorage.ts
+++ b/frontend/src/storage/canvasStorage.ts
@@ -1,0 +1,78 @@
+import {
+  CANVAS_DOCUMENT_VERSION,
+  type CanvasDocument,
+  type ExcalidrawElementStub,
+  assertCanvasDocument,
+  createEmptyCanvasDocument,
+  deserializeCanvasDocument,
+  isExcalidrawElementStub,
+} from '../types/CanvasDocument';
+import type { CodeCard } from '../types/CodeCard';
+import { isRecord } from '../types/utils';
+
+export type CanvasSceneSnapshot = {
+  elements: readonly ExcalidrawElementStub[];
+  appState?: Record<string, unknown>;
+  files?: Record<string, unknown>;
+  cards?: readonly CodeCard[];
+};
+
+export type ExcalidrawInitialDataSnapshot = {
+  elements: readonly ExcalidrawElementStub[];
+  appState: Record<string, unknown>;
+  files: Record<string, unknown>;
+};
+
+export function parseCanvasDocumentContent(content: string): CanvasDocument {
+  if (content.trim().length === 0) {
+    return createEmptyCanvasDocument();
+  }
+
+  return deserializeCanvasDocument(content);
+}
+
+export function createCanvasDocumentFromScene(scene: CanvasSceneSnapshot): CanvasDocument {
+  const document: CanvasDocument = {
+    version: CANVAS_DOCUMENT_VERSION,
+    elements: cloneElements(scene.elements),
+    cards: [...(scene.cards ?? [])],
+    appState: cloneRecord(scene.appState ?? {}),
+  };
+
+  const files = cloneRecord(scene.files ?? {});
+  if (Object.keys(files).length > 0) {
+    document.files = files;
+  }
+
+  assertCanvasDocument(document);
+  return document;
+}
+
+export function toExcalidrawInitialData(document: CanvasDocument): ExcalidrawInitialDataSnapshot {
+  return {
+    elements: document.elements,
+    appState: document.appState ?? {},
+    files: document.files ?? {},
+  };
+}
+
+function cloneElements(elements: readonly ExcalidrawElementStub[]): ExcalidrawElementStub[] {
+  const cloned = cloneJsonValue(elements, []);
+  if (!Array.isArray(cloned)) return [];
+
+  return cloned.filter(isExcalidrawElementStub);
+}
+
+function cloneRecord(value: Record<string, unknown>): Record<string, unknown> {
+  const cloned = cloneJsonValue(value, {});
+  return isRecord(cloned) ? cloned : {};
+}
+
+function cloneJsonValue(value: unknown, fallback: unknown): unknown {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? fallback : JSON.parse(serialized);
+  } catch {
+    return fallback;
+  }
+}

--- a/frontend/src/types/CanvasDocument.test.ts
+++ b/frontend/src/types/CanvasDocument.test.ts
@@ -39,6 +39,7 @@ describe('CanvasDocument', () => {
       elements: [{ id: 'element-1', type: 'rectangle' }],
       cards: [card],
       appState: { viewBackgroundColor: '#ffffff' },
+      files: { fileId: { id: 'fileId' } },
     };
 
     expect(deserializeCanvasDocument(serializeCanvasDocument(document))).toEqual(document);

--- a/frontend/src/types/CanvasDocument.test.ts
+++ b/frontend/src/types/CanvasDocument.test.ts
@@ -39,7 +39,7 @@ describe('CanvasDocument', () => {
       elements: [{ id: 'element-1', type: 'rectangle' }],
       cards: [card],
       appState: { viewBackgroundColor: '#ffffff' },
-      files: { fileId: { id: 'fileId' } },
+      files: { fileId: { id: 'fileId', dataURL: 'data:image/png;base64,', mimeType: 'image/png' } },
     };
 
     expect(deserializeCanvasDocument(serializeCanvasDocument(document))).toEqual(document);
@@ -66,6 +66,18 @@ describe('CanvasDocument', () => {
         elements: [{}],
         cards: [],
         appState: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('requires files to include Excalidraw binary file metadata', () => {
+    expect(
+      isCanvasDocument({
+        version: CANVAS_DOCUMENT_VERSION,
+        elements: [],
+        cards: [],
+        appState: {},
+        files: { fileId: { id: 'fileId' } },
       }),
     ).toBe(false);
   });

--- a/frontend/src/types/CanvasDocument.ts
+++ b/frontend/src/types/CanvasDocument.ts
@@ -9,12 +9,19 @@ export type ExcalidrawElementStub = {
   [key: string]: unknown;
 };
 
+export type CanvasBinaryFile = {
+  id: string;
+  dataURL: string;
+  mimeType: string;
+  [key: string]: unknown;
+};
+
 export type CanvasDocument = {
   version: typeof CANVAS_DOCUMENT_VERSION;
   elements: ExcalidrawElementStub[];
   cards: CodeCard[];
   appState?: Record<string, unknown>;
-  files?: Record<string, unknown>;
+  files?: Record<string, CanvasBinaryFile>;
 };
 
 export function createEmptyCanvasDocument(): CanvasDocument {
@@ -54,7 +61,8 @@ export function isCanvasDocument(value: unknown): value is CanvasDocument {
     Array.isArray(value.cards) &&
     value.cards.every(isCodeCard) &&
     (value.appState === undefined || isRecord(value.appState)) &&
-    (value.files === undefined || isRecord(value.files))
+    (value.files === undefined ||
+      (isRecord(value.files) && Object.values(value.files).every(isCanvasBinaryFile)))
   );
 }
 
@@ -66,4 +74,13 @@ export function assertCanvasDocument(value: unknown): asserts value is CanvasDoc
 
 export function isExcalidrawElementStub(value: unknown): value is ExcalidrawElementStub {
   return isRecord(value) && isNonEmptyString(value.id) && isNonEmptyString(value.type);
+}
+
+export function isCanvasBinaryFile(value: unknown): value is CanvasBinaryFile {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value.id) &&
+    isNonEmptyString(value.dataURL) &&
+    isNonEmptyString(value.mimeType)
+  );
 }

--- a/frontend/src/types/CanvasDocument.ts
+++ b/frontend/src/types/CanvasDocument.ts
@@ -14,6 +14,7 @@ export type CanvasDocument = {
   elements: ExcalidrawElementStub[];
   cards: CodeCard[];
   appState?: Record<string, unknown>;
+  files?: Record<string, unknown>;
 };
 
 export function createEmptyCanvasDocument(): CanvasDocument {
@@ -52,7 +53,8 @@ export function isCanvasDocument(value: unknown): value is CanvasDocument {
     value.elements.every(isExcalidrawElementStub) &&
     Array.isArray(value.cards) &&
     value.cards.every(isCodeCard) &&
-    (value.appState === undefined || isRecord(value.appState))
+    (value.appState === undefined || isRecord(value.appState)) &&
+    (value.files === undefined || isRecord(value.files))
   );
 }
 

--- a/frontend/src/vscodeBridge.test.ts
+++ b/frontend/src/vscodeBridge.test.ts
@@ -1,0 +1,62 @@
+import {
+  getInitialDocumentContent,
+  saveDocumentContent,
+  saveDocumentFile,
+  subscribeDocumentUpdates,
+} from './vscodeBridge';
+
+describe('vscodeBridge', () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'window', {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    delete window.__codetrace_initialContent;
+    delete window.__codetrace_onUpdate;
+    delete window.__codetrace_save;
+    delete window.__codetrace_saveFile;
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  it('reads the initial document content from the webview bootstrap', () => {
+    window.__codetrace_initialContent = '{"version":1}';
+
+    expect(getInitialDocumentContent()).toBe('{"version":1}');
+  });
+
+  it('subscribes and restores the previous update handler', () => {
+    const previous = jest.fn();
+    const next = jest.fn();
+    window.__codetrace_onUpdate = previous;
+
+    const unsubscribe = subscribeDocumentUpdates(next);
+    window.__codetrace_onUpdate?.('content');
+    unsubscribe();
+    window.__codetrace_onUpdate?.('again');
+
+    expect(next).toHaveBeenCalledWith('content');
+    expect(previous).toHaveBeenCalledWith('again');
+  });
+
+  it('posts document content to the extension save hook', () => {
+    const save = jest.fn();
+    window.__codetrace_save = save;
+
+    saveDocumentContent('content');
+
+    expect(save).toHaveBeenCalledWith('content');
+  });
+
+  it('posts document content to the extension save-file hook', () => {
+    const saveFile = jest.fn();
+    window.__codetrace_saveFile = saveFile;
+
+    saveDocumentFile('content');
+
+    expect(saveFile).toHaveBeenCalledWith('content');
+  });
+});

--- a/frontend/src/vscodeBridge.ts
+++ b/frontend/src/vscodeBridge.ts
@@ -1,0 +1,31 @@
+export type CodetraceUpdateHandler = (content: string) => void;
+
+declare global {
+  interface Window {
+    __codetrace_initialContent?: string;
+    __codetrace_onUpdate?: CodetraceUpdateHandler;
+    __codetrace_save?: (content: string) => void;
+    __codetrace_saveFile?: (content: string) => void;
+  }
+}
+
+export function getInitialDocumentContent(): string | undefined {
+  return window.__codetrace_initialContent;
+}
+
+export function subscribeDocumentUpdates(handler: CodetraceUpdateHandler): () => void {
+  const previousHandler = window.__codetrace_onUpdate;
+  window.__codetrace_onUpdate = handler;
+
+  return () => {
+    window.__codetrace_onUpdate = previousHandler;
+  };
+}
+
+export function saveDocumentContent(content: string): void {
+  window.__codetrace_save?.(content);
+}
+
+export function saveDocumentFile(content: string): void {
+  window.__codetrace_saveFile?.(content);
+}


### PR DESCRIPTION
﻿## Summary
- Wire the VS Code custom editor webview to load the built Vite frontend and bootstrap the current `.codetrace` document content.
- Persist Excalidraw scene state, appState, binary files, and CodeCard metadata through the CanvasDocument schema.
- Add webview save/update bridge handling, Ctrl/Cmd+S save-file flow, and create new canvases under `.codetrace/canvases/*.codetrace`.

## Validation
- `npm.cmd test --workspace=frontend -- --runInBand`
- `npm.cmd run build`
- `git diff --check`

Closes #8