### PR TITLE
feat(extension): add codetrace.addSelectionToCanvas command

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -18,8 +18,21 @@
       {
         "command": "codetrace.newCanvas",
         "title": "CodeTrace: New Canvas"
+      },
+      {
+        "command": "codetrace.addSelectionToCanvas",
+        "title": "CodeTrace: Add Selection to Canvas"
       }
     ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "codetrace.addSelectionToCanvas",
+          "when": "editorHasSelection",
+          "group": "codetrace@1"
+        }
+      ]
+    },
     "customEditors": [
       {
         "viewType": "codetrace.canvasEditor",

--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -35,8 +35,6 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel.onDidChangeViewState(() => {
       if (webviewPanel.active) {
         CanvasEditorProvider._activePanel = webviewPanel;
-      } else if (CanvasEditorProvider._activePanel === webviewPanel) {
-        CanvasEditorProvider._activePanel = undefined;
       }
     });
 

--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -3,6 +3,13 @@ import * as vscode from 'vscode';
 export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
   static readonly viewType = 'codetrace.canvasEditor';
 
+  private static readonly _panels = new Set<vscode.WebviewPanel>();
+  private static _activePanel: vscode.WebviewPanel | undefined;
+
+  static getActivePanel(): vscode.WebviewPanel | undefined {
+    return CanvasEditorProvider._activePanel;
+  }
+
   static register(context: vscode.ExtensionContext): vscode.Disposable {
     return vscode.window.registerCustomEditorProvider(
       CanvasEditorProvider.viewType,
@@ -20,6 +27,19 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     document: vscode.TextDocument,
     webviewPanel: vscode.WebviewPanel,
   ): Promise<void> {
+    CanvasEditorProvider._panels.add(webviewPanel);
+    if (webviewPanel.active) {
+      CanvasEditorProvider._activePanel = webviewPanel;
+    }
+
+    webviewPanel.onDidChangeViewState(() => {
+      if (webviewPanel.active) {
+        CanvasEditorProvider._activePanel = webviewPanel;
+      } else if (CanvasEditorProvider._activePanel === webviewPanel) {
+        CanvasEditorProvider._activePanel = undefined;
+      }
+    });
+
     webviewPanel.webview.options = {
       enableScripts: true,
       localResourceRoots: [
@@ -66,6 +86,10 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel.onDidDispose(() => {
       changeSubscription.dispose();
       saveSubscription.dispose();
+      CanvasEditorProvider._panels.delete(webviewPanel);
+      if (CanvasEditorProvider._activePanel === webviewPanel) {
+        CanvasEditorProvider._activePanel = undefined;
+      }
     });
 
     pushContent();
@@ -127,10 +151,12 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     window.__codetrace_initialContent = ${this._scriptString(initialContent)};
 
     window.addEventListener('message', event => {
-      const { type, content } = event.data ?? {};
+      const { type, content, card } = event.data ?? {};
       if (type === 'update' && typeof content === 'string') {
         window.__codetrace_initialContent = content;
         if (window.__codetrace_onUpdate) window.__codetrace_onUpdate(content);
+      } else if (type === 'addCard' && card != null) {
+        if (window.__codetrace_onAddCard) window.__codetrace_onAddCard(card);
       }
     });
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { CanvasEditorProvider } from './CanvasEditorProvider';
+import { generateUlid } from './ulid';
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(CanvasEditorProvider.register(context));
@@ -38,6 +39,62 @@ export function activate(context: vscode.ExtensionContext) {
       await vscode.workspace.fs.writeFile(file, new TextEncoder().encode(initial));
 
       await vscode.commands.executeCommand('vscode.openWith', file, CanvasEditorProvider.viewType);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('codetrace.addSelectionToCanvas', async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showErrorMessage('CodeTrace: 활성 에디터가 없습니다.');
+        return;
+      }
+
+      const selection = editor.selection;
+      if (selection.isEmpty) {
+        vscode.window.showErrorMessage('CodeTrace: 선택된 텍스트가 없습니다.');
+        return;
+      }
+
+      const panel = CanvasEditorProvider.getActivePanel();
+      if (!panel) {
+        vscode.window.showErrorMessage('CodeTrace: 열린 캔버스가 없습니다. 먼저 .codetrace 파일을 열어주세요.');
+        return;
+      }
+
+      const uri = editor.document.uri;
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+      if (!workspaceFolder) {
+        vscode.window.showErrorMessage('CodeTrace: 워크스페이스 외부 파일은 캔버스에 추가할 수 없습니다.');
+        return;
+      }
+
+      const absolutePath = uri.fsPath;
+      const workspacePath = workspaceFolder.uri.fsPath;
+      const relativePath = absolutePath
+        .slice(workspacePath.length)
+        .replace(/^[/\\]/, '')
+        .replace(/\\/g, '/');
+
+      const startLine = selection.start.line + 1;
+      const endLine = selection.end.line + 1;
+
+      const lines: string[] = [];
+      for (let i = selection.start.line; i <= selection.end.line; i++) {
+        lines.push(editor.document.lineAt(i).text);
+      }
+      const snapshot = lines.join('\n');
+
+      const card = {
+        id: generateUlid(),
+        file: { path: relativePath },
+        range: { startLine, endLine },
+        snapshot,
+        language: editor.document.languageId,
+        customData: {},
+      };
+
+      panel.webview.postMessage({ type: 'addCard', card });
     })
   );
 }

--- a/extension/src/ulid.ts
+++ b/extension/src/ulid.ts
@@ -1,0 +1,19 @@
+const ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+export function generateUlid(): string {
+  const now = Date.now();
+
+  let timeStr = '';
+  let t = now;
+  for (let i = 9; i >= 0; i--) {
+    timeStr = ENCODING[t % 32] + timeStr;
+    t = Math.floor(t / 32);
+  }
+
+  let randomStr = '';
+  for (let i = 0; i < 16; i++) {
+    randomStr += ENCODING[Math.floor(Math.random() * 32)];
+  }
+
+  return timeStr + randomStr;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import {
   getInitialDocumentContent,
   saveDocumentContent,
   saveDocumentFile,
+  subscribeAddCard,
   subscribeDocumentUpdates,
 } from './vscodeBridge';
 
@@ -85,6 +86,23 @@ export default function App() {
   }, []);
 
   useEffect(() => subscribeDocumentUpdates(applyDocumentContent), [applyDocumentContent]);
+
+  const handleAddCard = useCallback((card: CodeCard) => {
+    const newCards = [...cardsRef.current, card];
+    cardsRef.current = newCards;
+
+    const api = apiRef.current;
+    const elements = api ? (api.getSceneElements() as unknown as ExcalidrawElementStub[]) : [];
+    const document = createCanvasDocumentFromScene({
+      elements,
+      cards: newCards,
+    });
+    const content = serializeCanvasDocument(document);
+    latestContentRef.current = content;
+    saveDocumentContent(content);
+  }, []);
+
+  useEffect(() => subscribeAddCard(handleAddCard), [handleAddCard]);
 
   const handleExcalidrawAPI = useCallback((api: ExcalidrawImperativeAPI) => {
     apiRef.current = api;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -93,8 +93,12 @@ export default function App() {
 
     const api = apiRef.current;
     const elements = api ? (api.getSceneElements() as unknown as ExcalidrawElementStub[]) : [];
+    const appState = api ? (api.getAppState() as unknown as Record<string, unknown>) : undefined;
+    const files = api ? (api.getFiles() as unknown as Record<string, unknown>) : undefined;
     const document = createCanvasDocumentFromScene({
       elements,
+      appState,
+      files,
       cards: newCards,
     });
     const content = serializeCanvasDocument(document);

--- a/frontend/src/vscodeBridge.test.ts
+++ b/frontend/src/vscodeBridge.test.ts
@@ -2,8 +2,10 @@ import {
   getInitialDocumentContent,
   saveDocumentContent,
   saveDocumentFile,
+  subscribeAddCard,
   subscribeDocumentUpdates,
 } from './vscodeBridge';
+import type { CodeCard } from './types/CodeCard';
 
 describe('vscodeBridge', () => {
   beforeEach(() => {
@@ -17,6 +19,7 @@ describe('vscodeBridge', () => {
   afterEach(() => {
     delete window.__codetrace_initialContent;
     delete window.__codetrace_onUpdate;
+    delete window.__codetrace_onAddCard;
     delete window.__codetrace_save;
     delete window.__codetrace_saveFile;
     delete (globalThis as { window?: unknown }).window;
@@ -58,5 +61,28 @@ describe('vscodeBridge', () => {
     saveDocumentFile('content');
 
     expect(saveFile).toHaveBeenCalledWith('content');
+  });
+
+  it('subscribes and restores the previous addCard handler', () => {
+    const card: CodeCard = {
+      id: '01JVMH2N8S7T3K4P6Q8X9Y0Z12',
+      file: { path: 'src/index.ts' },
+      range: { startLine: 1, endLine: 3 },
+      snapshot: 'const x = 1;',
+      language: 'typescript',
+      customData: {},
+    };
+
+    const previous = jest.fn();
+    const next = jest.fn();
+    window.__codetrace_onAddCard = previous;
+
+    const unsubscribe = subscribeAddCard(next);
+    window.__codetrace_onAddCard?.(card);
+    unsubscribe();
+    window.__codetrace_onAddCard?.(card);
+
+    expect(next).toHaveBeenCalledWith(card);
+    expect(previous).toHaveBeenCalledWith(card);
   });
 });

--- a/frontend/src/vscodeBridge.ts
+++ b/frontend/src/vscodeBridge.ts
@@ -1,9 +1,13 @@
+import type { CodeCard } from './types/CodeCard';
+
 export type CodetraceUpdateHandler = (content: string) => void;
+export type CodetraceAddCardHandler = (card: CodeCard) => void;
 
 declare global {
   interface Window {
     __codetrace_initialContent?: string;
     __codetrace_onUpdate?: CodetraceUpdateHandler;
+    __codetrace_onAddCard?: CodetraceAddCardHandler;
     __codetrace_save?: (content: string) => void;
     __codetrace_saveFile?: (content: string) => void;
   }
@@ -28,4 +32,13 @@ export function saveDocumentContent(content: string): void {
 
 export function saveDocumentFile(content: string): void {
   window.__codetrace_saveFile?.(content);
+}
+
+export function subscribeAddCard(handler: CodetraceAddCardHandler): () => void {
+  const previousHandler = window.__codetrace_onAddCard;
+  window.__codetrace_onAddCard = handler;
+
+  return () => {
+    window.__codetrace_onAddCard = previousHandler;
+  };
 }


### PR DESCRIPTION
Closes #5

## Summary

- Registers `codetrace.addSelectionToCanvas` command in extension host and `editor/context` menu (shown only when `editorHasSelection`)
- `CanvasEditorProvider` tracks the most recently active canvas panel via `onDidChangeViewState` / `onDidDispose` static registry
- Command extracts full-line snapshot, 1-indexed line range, workspace-relative POSIX path, and language ID — builds a `CodeCard` with an inline ULID generator and posts `addCard` message to the active webview
- Webview side: `vscodeBridge` exposes `subscribeAddCard`; `App` handles the message by appending the card to `cardsRef`, reading current scene elements via `api.getSceneElements()`, and persisting via `saveDocumentContent` (no direct document write)
- Added `subscribeAddCard` unit test to `vscodeBridge.test.ts` (22 tests, all pass)

## Test plan

- [ ] Open a workspace and create a new canvas via `CodeTrace: New Canvas`
- [ ] Open a source file, select multiple lines, right-click → `CodeTrace: Add Selection to Canvas`
- [ ] Verify the `.codetrace` file is updated with the new card in `cards[]`
- [ ] Invoke command with no text selected via command palette — confirm error message shown
- [ ] Invoke command with no canvas open — confirm error message shown
- [ ] Invoke command from a file outside the workspace — confirm error message shown
- [ ] `npm test` in `frontend/` passes (22 tests)