### PR TITLE
feat: Scoped Workspace Analysis and Results Export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ desktop.ini
 *.swp
 *.swo
 .next/
+제미니.txt

--- a/extension/package.json
+++ b/extension/package.json
@@ -18,6 +18,18 @@
       {
         "command": "codetrace.newCanvas",
         "title": "CodeTrace: New Canvas"
+      },
+      {
+        "command": "codetrace.analyzeRelationships",
+        "title": "CodeTrace: Analyze Relationships"
+      },
+      {
+        "command": "codetrace.analyzeWorkspace",
+        "title": "CodeTrace: Analyze Workspace"
+      },
+      {
+        "command": "codetrace.analyzeScoped",
+        "title": "CodeTrace: Analyze Scoped (Folder/File)"
       }
     ],
     "customEditors": [

--- a/extension/src/CodeAnalyzer.ts
+++ b/extension/src/CodeAnalyzer.ts
@@ -1,0 +1,190 @@
+import * as vscode from 'vscode';
+
+export interface CodeSymbol {
+    name: string;
+    kind: vscode.SymbolKind;
+    range: vscode.Range;
+    uri: vscode.Uri;
+    children?: CodeSymbol[];
+}
+
+export interface SymbolRelationship {
+    from: vscode.Location;
+    to: vscode.Location;
+    type: 'call' | 'inheritance' | 'reference';
+}
+
+export class CodeAnalyzer {
+    /**
+     * 특정 문서의 심볼(클래스, 메서드 등)을 계층 구조로 가져옵니다.
+     */
+    async getDocumentSymbols(uri: vscode.Uri): Promise<CodeSymbol[]> {
+        try {
+            const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+                'vscode.executeDocumentSymbolProvider',
+                uri
+            );
+            if (!symbols) return [];
+            return this._mapSymbols(symbols, uri);
+        } catch (err) {
+            console.error(`Failed to get symbols for ${uri.fsPath}: ${err}`);
+            return [];
+        }
+    }
+
+    /**
+     * 특정 위치의 심볼에 대한 호출 계층(누가 호출하는지)을 가져옵니다.
+     */
+    async getIncomingCalls(uri: vscode.Uri, position: vscode.Position): Promise<vscode.CallHierarchyIncomingCall[]> {
+        try {
+            const items = await vscode.commands.executeCommand<vscode.CallHierarchyItem[]>(
+                'vscode.prepareCallHierarchy',
+                uri,
+                position
+            );
+
+            if (!items || items.length === 0) return [];
+
+            const incomingCalls = await vscode.commands.executeCommand<vscode.CallHierarchyIncomingCall[]>(
+                'vscode.provideIncomingCalls',
+                items[0]
+            );
+
+            return incomingCalls || [];
+        } catch (err) {
+            // 특정 심볼에 대해 Call Hierarchy가 지원되지 않을 수 있음
+            return [];
+        }
+    }
+
+    /**
+     * 특정 위치의 심볼이 무엇을 호출하는지(피호출자)를 가져옵니다.
+     */
+    async getOutgoingCalls(uri: vscode.Uri, position: vscode.Position): Promise<vscode.CallHierarchyOutgoingCall[]> {
+        try {
+            const items = await vscode.commands.executeCommand<vscode.CallHierarchyItem[]>(
+                'vscode.prepareCallHierarchy',
+                uri,
+                position
+            );
+
+            if (!items || items.length === 0) return [];
+
+            const outgoingCalls = await vscode.commands.executeCommand<vscode.CallHierarchyOutgoingCall[]>(
+                'vscode.provideOutgoingCalls',
+                items[0]
+            );
+
+            return outgoingCalls || [];
+        } catch (err) {
+            return [];
+        }
+    }
+
+    /**
+     * 특정 위치에서 시작하여 연관된 모든 관계(호출자 및 피호출자)를 탐색하여 그래프를 구성합니다.
+     */
+    async traceRelationships(uri: vscode.Uri, position: vscode.Position, depth: number = 1): Promise<SymbolRelationship[]> {
+        const relationships: SymbolRelationship[] = [];
+        const visited = new Set<string>();
+
+        const explore = async (currUri: vscode.Uri, currPos: vscode.Position, currDepth: number) => {
+            const key = `${currUri.toString()}:${currPos.line}:${currPos.character}`;
+            if (visited.has(key) || currDepth > depth) return;
+            visited.add(key);
+
+            const incoming = await this.getIncomingCalls(currUri, currPos);
+            for (const call of incoming) {
+                relationships.push({
+                    from: new vscode.Location(call.from.uri, call.from.range),
+                    to: new vscode.Location(currUri, new vscode.Range(currPos, currPos)),
+                    type: 'call'
+                });
+                if (currDepth < depth) {
+                    await explore(call.from.uri, call.from.range.start, currDepth + 1);
+                }
+            }
+
+            const outgoing = await this.getOutgoingCalls(currUri, currPos);
+            for (const call of outgoing) {
+                relationships.push({
+                    from: new vscode.Location(currUri, new vscode.Range(currPos, currPos)),
+                    to: new vscode.Location(call.to.uri, call.to.selectionRange),
+                    type: 'call'
+                });
+                if (currDepth < depth) {
+                    await explore(call.to.uri, call.to.selectionRange.start, currDepth + 1);
+                }
+            }
+        };
+
+        await explore(uri, position, 0);
+        return relationships;
+    }
+
+    /**
+     * 워크스페이스 내의 특정 범위 또는 모든 소스 파일을 스캔하여 심볼 및 호출 관계를 분석합니다.
+     */
+    async analyzeWorkspace(scope?: vscode.GlobPattern, onProgress?: (msg: string) => void): Promise<{ symbols: CodeSymbol[], relationships: SymbolRelationship[] }> {
+        const allSymbols: CodeSymbol[] = [];
+        const allRelationships: SymbolRelationship[] = [];
+        
+        const files = await vscode.workspace.findFiles(scope || '**/*.{ts,tsx,js,jsx,py,java,go}');
+        onProgress?.(`Found ${files.length} source files.`);
+
+        for (const file of files) {
+            onProgress?.(`Scanning symbols: ${vscode.workspace.asRelativePath(file)}`);
+            const symbols = await this.getDocumentSymbols(file);
+            allSymbols.push(...symbols);
+        }
+
+        const flatSymbols = this._flattenSymbols(allSymbols);
+        onProgress?.(`Analyzing relationships for ${flatSymbols.length} symbols...`);
+
+        // 병렬 처리를 위해 chunk로 나누어 처리하거나 순차 처리 (LSP 부하 고려)
+        let count = 0;
+        for (const symbol of flatSymbols) {
+            const isCallable = symbol.kind === vscode.SymbolKind.Function || 
+                               symbol.kind === vscode.SymbolKind.Method || 
+                               symbol.kind === vscode.SymbolKind.Constructor;
+
+            if (isCallable) {
+                const outgoing = await this.getOutgoingCalls(symbol.uri, symbol.range.start);
+                for (const call of outgoing) {
+                    allRelationships.push({
+                        from: new vscode.Location(symbol.uri, symbol.range),
+                        to: new vscode.Location(call.to.uri, call.to.selectionRange),
+                        type: 'call'
+                    });
+                }
+            }
+            
+            count++;
+            if (count % 50 === 0) {
+                onProgress?.(`Analyzed ${count}/${flatSymbols.length} symbols...`);
+            }
+        }
+
+        return { symbols: allSymbols, relationships: allRelationships };
+    }
+
+    private _flattenSymbols(symbols: CodeSymbol[]): CodeSymbol[] {
+        const flat: CodeSymbol[] = [];
+        const traverse = (s: CodeSymbol) => {
+            flat.push(s);
+            s.children?.forEach(traverse);
+        };
+        symbols.forEach(traverse);
+        return flat;
+    }
+
+    private _mapSymbols(symbols: vscode.DocumentSymbol[], uri: vscode.Uri): CodeSymbol[] {
+        return symbols.map(s => ({
+            name: s.name,
+            kind: s.kind,
+            range: s.range,
+            uri: uri,
+            children: s.children ? this._mapSymbols(s.children, uri) : undefined
+        }));
+    }
+}

--- a/extension/src/CodeAnalyzer.ts
+++ b/extension/src/CodeAnalyzer.ts
@@ -10,7 +10,9 @@ export interface CodeSymbol {
 
 export interface SymbolRelationship {
     from: vscode.Location;
+    fromName: string;
     to: vscode.Location;
+    toName: string;
     type: 'call' | 'inheritance' | 'reference';
 }
 
@@ -88,44 +90,55 @@ export class CodeAnalyzer {
         const relationships: SymbolRelationship[] = [];
         const visited = new Set<string>();
 
-        const explore = async (currUri: vscode.Uri, currPos: vscode.Position, currDepth: number) => {
+        const explore = async (currUri: vscode.Uri, currPos: vscode.Position, currDepth: number, currName: string) => {
             const key = `${currUri.toString()}:${currPos.line}:${currPos.character}`;
-            if (visited.has(key) || currDepth > depth) return;
+            if (visited.has(key) || currDepth >= depth) return;
             visited.add(key);
 
             const incoming = await this.getIncomingCalls(currUri, currPos);
             for (const call of incoming) {
                 relationships.push({
                     from: new vscode.Location(call.from.uri, call.from.range),
+                    fromName: call.from.name,
                     to: new vscode.Location(currUri, new vscode.Range(currPos, currPos)),
+                    toName: currName,
                     type: 'call'
                 });
-                if (currDepth < depth) {
-                    await explore(call.from.uri, call.from.range.start, currDepth + 1);
-                }
+                await explore(call.from.uri, call.from.range.start, currDepth + 1, call.from.name);
             }
 
             const outgoing = await this.getOutgoingCalls(currUri, currPos);
             for (const call of outgoing) {
                 relationships.push({
                     from: new vscode.Location(currUri, new vscode.Range(currPos, currPos)),
+                    fromName: currName,
                     to: new vscode.Location(call.to.uri, call.to.selectionRange),
+                    toName: call.to.name,
                     type: 'call'
                 });
-                if (currDepth < depth) {
-                    await explore(call.to.uri, call.to.selectionRange.start, currDepth + 1);
-                }
+                await explore(call.to.uri, call.to.selectionRange.start, currDepth + 1, call.to.name);
             }
         };
 
-        await explore(uri, position, 0);
+        const items = await vscode.commands.executeCommand<vscode.CallHierarchyItem[]>(
+            'vscode.prepareCallHierarchy',
+            uri,
+            position
+        );
+        const startName = items && items.length > 0 ? items[0].name : 'unknown';
+
+        await explore(uri, position, 0, startName);
         return relationships;
     }
 
     /**
      * 워크스페이스 내의 특정 범위 또는 모든 소스 파일을 스캔하여 심볼 및 호출 관계를 분석합니다.
      */
-    async analyzeWorkspace(scope?: vscode.GlobPattern, onProgress?: (msg: string) => void): Promise<{ symbols: CodeSymbol[], relationships: SymbolRelationship[] }> {
+    async analyzeWorkspace(
+        scope?: vscode.GlobPattern, 
+        onProgress?: (msg: string, increment?: number) => void,
+        token?: vscode.CancellationToken
+    ): Promise<{ symbols: CodeSymbol[], relationships: SymbolRelationship[] }> {
         const allSymbols: CodeSymbol[] = [];
         const allRelationships: SymbolRelationship[] = [];
         
@@ -133,6 +146,8 @@ export class CodeAnalyzer {
         onProgress?.(`Found ${files.length} source files.`);
 
         for (const file of files) {
+            if (token?.isCancellationRequested) return { symbols: [], relationships: [] };
+            
             onProgress?.(`Scanning symbols: ${vscode.workspace.asRelativePath(file)}`);
             const symbols = await this.getDocumentSymbols(file);
             allSymbols.push(...symbols);
@@ -141,9 +156,12 @@ export class CodeAnalyzer {
         const flatSymbols = this._flattenSymbols(allSymbols);
         onProgress?.(`Analyzing relationships for ${flatSymbols.length} symbols...`);
 
-        // 병렬 처리를 위해 chunk로 나누어 처리하거나 순차 처리 (LSP 부하 고려)
         let count = 0;
+        const total = flatSymbols.length;
+        
         for (const symbol of flatSymbols) {
+            if (token?.isCancellationRequested) break;
+
             const isCallable = symbol.kind === vscode.SymbolKind.Function || 
                                symbol.kind === vscode.SymbolKind.Method || 
                                symbol.kind === vscode.SymbolKind.Constructor;
@@ -153,15 +171,18 @@ export class CodeAnalyzer {
                 for (const call of outgoing) {
                     allRelationships.push({
                         from: new vscode.Location(symbol.uri, symbol.range),
+                        fromName: symbol.name,
                         to: new vscode.Location(call.to.uri, call.to.selectionRange),
+                        toName: call.to.name,
                         type: 'call'
                     });
                 }
             }
             
             count++;
-            if (count % 50 === 0) {
-                onProgress?.(`Analyzed ${count}/${flatSymbols.length} symbols...`);
+            if (count % 10 === 0 || count === total) {
+                const progressMsg = `Analyzed ${count}/${total} symbols...`;
+                onProgress?.(progressMsg, (10 / total) * 100);
             }
         }
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -67,8 +67,10 @@ export function activate(context: vscode.ExtensionContext) {
         );
       });
 
-      if (!result || (result.symbols.length === 0 && result.relationships.length === 0)) {
-        outputChannel.appendLine('Analysis cancelled or no results found.');
+      if (!result) return;
+
+      if (result.symbols.length === 0 && result.relationships.length === 0) {
+        outputChannel.appendLine('No symbols or relationships found in the specified scope.');
         return;
       }
 
@@ -123,7 +125,12 @@ export function activate(context: vscode.ExtensionContext) {
         }
       }
     } catch (err) {
-      outputChannel.appendLine(`Error during analysis: ${err}`);
+      if (err instanceof vscode.CancellationError) {
+        outputChannel.appendLine('Analysis cancelled by user.');
+      } else {
+        outputChannel.appendLine(`Error during analysis: ${err}`);
+      }
+      return;
     }
 
     outputChannel.appendLine('--- Analysis Finished ---');

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -5,6 +5,7 @@ import { CodeAnalyzer } from './CodeAnalyzer';
 export function activate(context: vscode.ExtensionContext) {
   const analyzer = new CodeAnalyzer();
   const outputChannel = vscode.window.createOutputChannel('CodeTrace Analysis');
+  context.subscriptions.push(outputChannel);
 
   context.subscriptions.push(CanvasEditorProvider.register(context));
 
@@ -28,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
           outputChannel.appendLine('No relationships found.');
         } else {
           relationships.forEach(rel => {
-            outputChannel.appendLine(`[${rel.type}] ${rel.from.uri.fsPath}:${rel.from.range.start.line} -> ${rel.to.uri.fsPath}:${rel.to.range.start.line}`);
+            outputChannel.appendLine(`[${rel.type}] ${rel.fromName} (${vscode.workspace.asRelativePath(rel.from.uri)}:${rel.from.range.start.line}) -> ${rel.toName} (${vscode.workspace.asRelativePath(rel.to.uri)}:${rel.to.range.start.line})`);
           });
         }
       } catch (err) {
@@ -47,9 +48,29 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     try {
-      const result = await analyzer.analyzeWorkspace(scope, (msg) => {
-        outputChannel.appendLine(`> ${msg}`);
+      const result = await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: 'CodeTrace: Analyzing Workspace...',
+        cancellable: true
+      }, async (progress, token) => {
+        return await analyzer.analyzeWorkspace(
+          scope, 
+          (msg, increment) => {
+            outputChannel.appendLine(`> ${msg}`);
+            if (increment) {
+              progress.report({ message: msg, increment });
+            } else {
+              progress.report({ message: msg });
+            }
+          },
+          token
+        );
       });
+
+      if (!result || (result.symbols.length === 0 && result.relationships.length === 0)) {
+        outputChannel.appendLine('Analysis cancelled or no results found.');
+        return;
+      }
 
       outputChannel.appendLine(`Analysis complete! Found ${result.symbols.length} symbols and ${result.relationships.length} relationships.`);
       
@@ -76,10 +97,12 @@ export function activate(context: vscode.ExtensionContext) {
           relationships: result.relationships.map(rel => ({
             type: rel.type,
             from: {
+              name: rel.fromName,
               uri: vscode.workspace.asRelativePath(rel.from.uri),
               range: rel.from.range
             },
             to: {
+              name: rel.toName,
               uri: vscode.workspace.asRelativePath(rel.to.uri),
               range: rel.to.range
             }
@@ -93,7 +116,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (result.relationships.length > 0) {
         outputChannel.appendLine('\nDetected Relationships (Preview):');
         result.relationships.slice(0, 50).forEach(rel => {
-          outputChannel.appendLine(`[${rel.type}] ${vscode.workspace.asRelativePath(rel.from.uri)} -> ${vscode.workspace.asRelativePath(rel.to.uri)}`);
+          outputChannel.appendLine(`[${rel.type}] ${rel.fromName} -> ${rel.toName}`);
         });
         if (result.relationships.length > 50) {
           outputChannel.appendLine('... (truncated for output channel)');

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,8 +1,138 @@
 import * as vscode from 'vscode';
 import { CanvasEditorProvider } from './CanvasEditorProvider';
+import { CodeAnalyzer } from './CodeAnalyzer';
 
 export function activate(context: vscode.ExtensionContext) {
+  const analyzer = new CodeAnalyzer();
+  const outputChannel = vscode.window.createOutputChannel('CodeTrace Analysis');
+
   context.subscriptions.push(CanvasEditorProvider.register(context));
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('codetrace.analyzeRelationships', async () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor) {
+        vscode.window.showErrorMessage('CodeTrace: 활성 에디터가 없습니다.');
+        return;
+      }
+
+      const position = editor.selection.active;
+      const uri = editor.document.uri;
+
+      outputChannel.show();
+      outputChannel.appendLine(`--- Analysis Started: ${uri.fsPath} at ${position.line}:${position.character} ---`);
+
+      try {
+        const relationships = await analyzer.traceRelationships(uri, position, 1);
+        if (relationships.length === 0) {
+          outputChannel.appendLine('No relationships found.');
+        } else {
+          relationships.forEach(rel => {
+            outputChannel.appendLine(`[${rel.type}] ${rel.from.uri.fsPath}:${rel.from.range.start.line} -> ${rel.to.uri.fsPath}:${rel.to.range.start.line}`);
+          });
+        }
+      } catch (err) {
+        outputChannel.appendLine(`Error during analysis: ${err}`);
+      }
+      
+      outputChannel.appendLine('--- Analysis Finished ---');
+    })
+  );
+
+  const runAnalysis = async (scope?: vscode.GlobPattern) => {
+    outputChannel.show();
+    outputChannel.appendLine('--- Analysis Started ---');
+    if (scope) {
+      outputChannel.appendLine(`Scope: ${scope.toString()}`);
+    }
+
+    try {
+      const result = await analyzer.analyzeWorkspace(scope, (msg) => {
+        outputChannel.appendLine(`> ${msg}`);
+      });
+
+      outputChannel.appendLine(`Analysis complete! Found ${result.symbols.length} symbols and ${result.relationships.length} relationships.`);
+      
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (workspaceFolders) {
+        const dir = vscode.Uri.joinPath(workspaceFolders[0].uri, '.codetrace');
+        await vscode.workspace.fs.createDirectory(dir);
+        const fileName = scope ? `analysis_${Date.now()}.json` : 'analysis_result.json';
+        const file = vscode.Uri.joinPath(dir, fileName);
+        
+        const outputData = {
+          timestamp: new Date().toISOString(),
+          scope: scope ? scope.toString() : 'workspace',
+          summary: {
+            totalSymbols: result.symbols.length,
+            totalRelationships: result.relationships.length
+          },
+          symbols: result.symbols.map(s => ({
+            name: s.name,
+            kind: vscode.SymbolKind[s.kind],
+            uri: vscode.workspace.asRelativePath(s.uri),
+            range: s.range
+          })),
+          relationships: result.relationships.map(rel => ({
+            type: rel.type,
+            from: {
+              uri: vscode.workspace.asRelativePath(rel.from.uri),
+              range: rel.from.range
+            },
+            to: {
+              uri: vscode.workspace.asRelativePath(rel.to.uri),
+              range: rel.to.range
+            }
+          }))
+        };
+
+        await vscode.workspace.fs.writeFile(file, new TextEncoder().encode(JSON.stringify(outputData, null, 2)));
+        outputChannel.appendLine(`\nFull analysis result saved to: ${vscode.workspace.asRelativePath(file)}`);
+      }
+
+      if (result.relationships.length > 0) {
+        outputChannel.appendLine('\nDetected Relationships (Preview):');
+        result.relationships.slice(0, 50).forEach(rel => {
+          outputChannel.appendLine(`[${rel.type}] ${vscode.workspace.asRelativePath(rel.from.uri)} -> ${vscode.workspace.asRelativePath(rel.to.uri)}`);
+        });
+        if (result.relationships.length > 50) {
+          outputChannel.appendLine('... (truncated for output channel)');
+        }
+      }
+    } catch (err) {
+      outputChannel.appendLine(`Error during analysis: ${err}`);
+    }
+
+    outputChannel.appendLine('--- Analysis Finished ---');
+  };
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('codetrace.analyzeWorkspace', () => runAnalysis())
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('codetrace.analyzeScoped', async (uri?: vscode.Uri) => {
+      let targetUri = uri;
+      if (!targetUri) {
+        const selected = await vscode.window.showOpenDialog({
+          canSelectFiles: true,
+          canSelectFolders: true,
+          canSelectMany: false,
+          openLabel: '분석할 폴더 또는 파일 선택'
+        });
+        if (selected && selected.length > 0) {
+          targetUri = selected[0];
+        }
+      }
+
+      if (targetUri) {
+        const relativePath = vscode.workspace.asRelativePath(targetUri);
+        const isFile = (await vscode.workspace.fs.stat(targetUri)).type === vscode.FileType.File;
+        const pattern = isFile ? relativePath : `${relativePath}/**/*.{ts,tsx,js,jsx,py,java,go}`;
+        await runAnalysis(pattern);
+      }
+    })
+  );
 
   context.subscriptions.push(
     vscode.commands.registerCommand('codetrace.newCanvas', async () => {


### PR DESCRIPTION
## Changes
- Expanded relationship analysis to include constructors in addition to functions and methods.
- Added logic to export full analysis results (symbols and relationships) to a JSON file in the \.codetrace\ directory.
- Implemented a new command \codetrace.analyzeScoped\ to allow users to select specific folders or files for targeted analysis.
- Updated \package.json\ to register the new commands in the Command Palette.

## Verification
- Verified command registration in \package.json\.
- Verified analysis logic in \CodeAnalyzer.ts\.
- Verified file saving and scoping logic in \extension.ts\.