### PR TITLE
[codex] Implement code card UI elements

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import type {
   ExcalidrawImperativeAPI,
   ExcalidrawInitialDataState,
 } from '@excalidraw/excalidraw/types/types';
+import { CODE_CARD_WIDTH, createCodeCardElements } from './codeCards/codeCardElements';
 import {
   createCanvasDocumentFromScene,
   parseCanvasDocumentContent,
@@ -28,6 +29,44 @@ type ExcalidrawChangeHandler = NonNullable<ComponentProps<typeof Excalidraw>['on
 
 function readInitialDocument() {
   return parseCanvasDocumentContent(getInitialDocumentContent() ?? '');
+}
+
+function getNextCodeCardPosition(appState: Record<string, unknown> | undefined, cardIndex: number) {
+  const zoom = getZoomValue(appState);
+  const viewport = getViewportSize();
+  const width = getNumber(appState?.width, viewport.width);
+  const height = getNumber(appState?.height, viewport.height);
+  const scrollX = getNumber(appState?.scrollX, 0);
+  const scrollY = getNumber(appState?.scrollY, 0);
+  const cascadeOffset = (cardIndex % 8) * 28;
+
+  return {
+    x: Math.round((width / 2 - scrollX) / zoom - CODE_CARD_WIDTH / 2 + cascadeOffset),
+    y: Math.round((height * 0.25 - scrollY) / zoom + cascadeOffset),
+  };
+}
+
+function getZoomValue(appState: Record<string, unknown> | undefined): number {
+  const zoom = appState?.zoom;
+  if (typeof zoom !== 'object' || zoom === null || !('value' in zoom)) return 1;
+
+  const value = (zoom as { value?: unknown }).value;
+  return typeof value === 'number' && value > 0 ? value : 1;
+}
+
+function getNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function getViewportSize() {
+  if (typeof window === 'undefined') {
+    return { width: 1200, height: 800 };
+  }
+
+  return {
+    width: window.innerWidth || 1200,
+    height: window.innerHeight || 800,
+  };
 }
 
 export default function App() {
@@ -95,8 +134,26 @@ export default function App() {
     const elements = api ? (api.getSceneElements() as unknown as ExcalidrawElementStub[]) : [];
     const appState = api ? (api.getAppState() as unknown as Record<string, unknown>) : undefined;
     const files = api ? (api.getFiles() as unknown as Record<string, unknown>) : undefined;
+    const nextElements = api
+      ? [
+          ...elements,
+          ...createCodeCardElements(card, getNextCodeCardPosition(appState, newCards.length - 1)),
+        ]
+      : elements;
+
+    if (api) {
+      isApplyingDocumentRef.current = true;
+      api.updateScene({
+        elements: nextElements as unknown as ExcalidrawElement[],
+        commitToHistory: true,
+      });
+      window.setTimeout(() => {
+        isApplyingDocumentRef.current = false;
+      }, 0);
+    }
+
     const document = createCanvasDocumentFromScene({
-      elements,
+      elements: nextElements,
       appState,
       files,
       cards: newCards,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,22 +27,27 @@ import {
 
 type ExcalidrawChangeHandler = NonNullable<ComponentProps<typeof Excalidraw>['onChange']>;
 
+const CARD_STACK_COLUMNS = 4;
+const CARD_STACK_COLUMN_OFFSET = 32;
+const CARD_STACK_ROW_OFFSET = 220;
+
 function readInitialDocument() {
   return parseCanvasDocumentContent(getInitialDocumentContent() ?? '');
 }
 
 function getNextCodeCardPosition(appState: Record<string, unknown> | undefined, cardIndex: number) {
   const zoom = getZoomValue(appState);
-  const viewport = getViewportSize();
-  const width = getNumber(appState?.width, viewport.width);
-  const height = getNumber(appState?.height, viewport.height);
+  const viewport = getViewportSize(appState);
   const scrollX = getNumber(appState?.scrollX, 0);
   const scrollY = getNumber(appState?.scrollY, 0);
-  const cascadeOffset = (cardIndex % 8) * 28;
+  const stackColumn = cardIndex % CARD_STACK_COLUMNS;
+  const stackRow = Math.floor(cardIndex / CARD_STACK_COLUMNS);
+  const xOffset = stackColumn * CARD_STACK_COLUMN_OFFSET;
+  const yOffset = stackColumn * CARD_STACK_COLUMN_OFFSET + stackRow * CARD_STACK_ROW_OFFSET;
 
   return {
-    x: Math.round((width / 2 - scrollX) / zoom - CODE_CARD_WIDTH / 2 + cascadeOffset),
-    y: Math.round((height * 0.25 - scrollY) / zoom + cascadeOffset),
+    x: Math.round((viewport.width / 2 - scrollX) / zoom - CODE_CARD_WIDTH / 2 + xOffset),
+    y: Math.round((viewport.height * 0.25 - scrollY) / zoom + yOffset),
   };
 }
 
@@ -58,14 +63,17 @@ function getNumber(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }
 
-function getViewportSize() {
+function getViewportSize(appState: Record<string, unknown> | undefined) {
+  const fallbackWidth = getNumber(appState?.width, 1200);
+  const fallbackHeight = getNumber(appState?.height, 800);
+
   if (typeof window === 'undefined') {
-    return { width: 1200, height: 800 };
+    return { width: fallbackWidth, height: fallbackHeight };
   }
 
   return {
-    width: window.innerWidth || 1200,
-    height: window.innerHeight || 800,
+    width: window.innerWidth || fallbackWidth,
+    height: window.innerHeight || fallbackHeight,
   };
 }
 
@@ -77,7 +85,6 @@ export default function App() {
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
   const cardsRef = useRef<CodeCard[]>([]);
   const latestContentRef = useRef<string>(initialContent);
-  const isApplyingDocumentRef = useRef(false);
 
   useEffect(() => {
     cardsRef.current = initialDocument.cards;
@@ -105,7 +112,6 @@ export default function App() {
 
     if (!api) return;
 
-    isApplyingDocumentRef.current = true;
     const files = Object.values(document.files ?? {}) as BinaryFileData[];
     if (files.length > 0) {
       api.addFiles(files);
@@ -118,10 +124,6 @@ export default function App() {
       },
       commitToHistory: false,
     });
-    // Excalidraw may emit onChange after updateScene; suppress those document echoes on the next tick.
-    window.setTimeout(() => {
-      isApplyingDocumentRef.current = false;
-    }, 0);
   }, []);
 
   useEffect(() => subscribeDocumentUpdates(applyDocumentContent), [applyDocumentContent]);
@@ -131,29 +133,28 @@ export default function App() {
     cardsRef.current = newCards;
 
     const api = apiRef.current;
-    const elements = api ? (api.getSceneElements() as unknown as ExcalidrawElementStub[]) : [];
-    const appState = api ? (api.getAppState() as unknown as Record<string, unknown>) : undefined;
-    const files = api ? (api.getFiles() as unknown as Record<string, unknown>) : undefined;
-    const nextElements = api
-      ? [
-          ...elements,
-          ...createCodeCardElements(card, getNextCodeCardPosition(appState, newCards.length - 1)),
-        ]
-      : elements;
+    let elements = api ? (api.getSceneElements() as unknown as ExcalidrawElementStub[]) : [];
+    let appState = api ? (api.getAppState() as unknown as Record<string, unknown>) : undefined;
+    let files = api ? (api.getFiles() as unknown as Record<string, unknown>) : undefined;
 
     if (api) {
-      isApplyingDocumentRef.current = true;
+      const nextElements = [
+        ...elements,
+        ...createCodeCardElements(card, getNextCodeCardPosition(appState, newCards.length - 1)),
+      ];
+
       api.updateScene({
         elements: nextElements as unknown as ExcalidrawElement[],
         commitToHistory: true,
       });
-      window.setTimeout(() => {
-        isApplyingDocumentRef.current = false;
-      }, 0);
+
+      elements = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+      appState = api.getAppState() as unknown as Record<string, unknown>;
+      files = api.getFiles() as unknown as Record<string, unknown>;
     }
 
     const document = createCanvasDocumentFromScene({
-      elements: nextElements,
+      elements,
       appState,
       files,
       cards: newCards,
@@ -171,8 +172,6 @@ export default function App() {
 
   const handleChange = useCallback<ExcalidrawChangeHandler>(
     (elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {
-      if (isApplyingDocumentRef.current) return;
-
       const document = createCanvasDocumentFromScene({
         elements: elements as unknown as ExcalidrawElementStub[],
         appState: appState as unknown as Record<string, unknown>,

--- a/frontend/src/codeCards/codeCardElements.test.ts
+++ b/frontend/src/codeCards/codeCardElements.test.ts
@@ -1,0 +1,106 @@
+import type { CodeCard } from '../types/CodeCard';
+import { createCodeCardElements, getCodeCardGroupId, isCodeCardStale } from './codeCardElements';
+
+const card: CodeCard = {
+  id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+  file: {
+    path: 'frontend/src/App.tsx',
+    gitCommit: 'e66b61677b54f0f4c04a82f7c9a86f0f4a2e8a1b',
+  },
+  range: {
+    startLine: 10,
+    endLine: 12,
+  },
+  snapshot: ['export function App() {', '  return <div />;', '}'].join('\n'),
+  language: 'typescriptreact',
+  customData: {},
+};
+
+describe('codeCardElements', () => {
+  it('creates grouped Excalidraw elements with CodeTrace custom data', () => {
+    const elements = createCodeCardElements(card, { x: 100, y: 200, updated: 123 });
+    const groupId = getCodeCardGroupId(card.id);
+
+    expect(elements).toHaveLength(5);
+    expect(elements.every(element => element.groupIds instanceof Array)).toBe(true);
+    expect(elements.every(element => (element.groupIds as string[]).includes(groupId))).toBe(true);
+    expect(elements.every(element => getCustomData(element).kind === 'codeCard')).toBe(true);
+    expect(elements.every(element => getCustomData(element).cardId === card.id)).toBe(true);
+
+    const container = getElementByRole(elements, 'container');
+    expect(container).toMatchObject({
+      type: 'rectangle',
+      x: 100,
+      y: 200,
+      customData: {
+        codetrace: {
+          filePath: 'frontend/src/App.tsx',
+          range: { startLine: 10, endLine: 12 },
+          stale: false,
+        },
+      },
+    });
+  });
+
+  it('renders a monospace code snapshot with line numbers', () => {
+    const elements = createCodeCardElements(card, { updated: 123 });
+    const snapshot = getElementByRole(elements, 'snapshot');
+
+    expect(snapshot.type).toBe('text');
+    expect(snapshot.fontFamily).toBe(3);
+    expect(snapshot.text).toContain('10 | export function App() {');
+    expect(snapshot.text).toContain('11 |   return <div />;');
+  });
+
+  it('adds a stale marker when card custom data marks the snapshot stale', () => {
+    const staleCard: CodeCard = {
+      ...card,
+      customData: {
+        stale: true,
+      },
+    };
+
+    const elements = createCodeCardElements(staleCard, { updated: 123 });
+    const staleElements = elements.filter(element =>
+      String(getCustomData(element).role).startsWith('staleMarker'),
+    );
+    const container = getElementByRole(elements, 'container');
+
+    expect(isCodeCardStale(staleCard)).toBe(true);
+    expect(staleElements).toHaveLength(2);
+    expect(new Set(staleElements.map(element => element.id)).size).toBe(2);
+    expect(staleElements.some(element => element.text === 'STALE')).toBe(true);
+    expect(container.customData).toMatchObject({
+      codetrace: {
+        stale: true,
+      },
+    });
+  });
+
+  it('accepts nested codetrace stale metadata for future update flows', () => {
+    const staleCard: CodeCard = {
+      ...card,
+      customData: {
+        codetrace: {
+          stale: true,
+        },
+      },
+    };
+
+    expect(isCodeCardStale(staleCard)).toBe(true);
+  });
+});
+
+function getElementByRole(elements: Record<string, unknown>[], role: string): Record<string, unknown> {
+  const element = elements.find(element => getCustomData(element).role === role);
+  if (!element) {
+    throw new Error(`Missing element with role ${role}`);
+  }
+
+  return element;
+}
+
+function getCustomData(element: Record<string, unknown>): Record<string, unknown> {
+  const customData = element.customData as { codetrace?: Record<string, unknown> } | undefined;
+  return customData?.codetrace ?? {};
+}

--- a/frontend/src/codeCards/codeCardElements.test.ts
+++ b/frontend/src/codeCards/codeCardElements.test.ts
@@ -52,6 +52,19 @@ describe('codeCardElements', () => {
     expect(snapshot.text).toContain('11 |   return <div />;');
   });
 
+  it('regenerates version nonces when recreating card elements', () => {
+    const random = jest.spyOn(Math, 'random');
+    random.mockReturnValue(0.1);
+    const firstContainer = getElementByRole(createCodeCardElements(card, { updated: 123 }), 'container');
+
+    random.mockReturnValue(0.2);
+    const nextContainer = getElementByRole(createCodeCardElements(card, { updated: 123 }), 'container');
+
+    expect(firstContainer.seed).toBe(nextContainer.seed);
+    expect(firstContainer.versionNonce).not.toBe(nextContainer.versionNonce);
+    random.mockRestore();
+  });
+
   it('adds a stale marker when card custom data marks the snapshot stale', () => {
     const staleCard: CodeCard = {
       ...card,

--- a/frontend/src/codeCards/codeCardElements.ts
+++ b/frontend/src/codeCards/codeCardElements.ts
@@ -1,0 +1,322 @@
+import type { ExcalidrawElementStub } from '../types/CanvasDocument';
+import type { CodeCard } from '../types/CodeCard';
+
+export const CODE_CARD_WIDTH = 520;
+
+const CARD_PADDING = 18;
+const HEADER_HEIGHT = 50;
+const CODE_PADDING = 14;
+const CODE_FONT_SIZE = 14;
+const TITLE_FONT_SIZE = 17;
+const META_FONT_SIZE = 12;
+const MARKER_FONT_SIZE = 11;
+const TEXT_LINE_HEIGHT = 1.25;
+const MAX_CODE_LINES = 14;
+const MAX_CODE_COLUMNS = 74;
+const MIN_CODE_HEIGHT = 80;
+const FONT_FAMILY_CASCADIA = 3;
+const ROUNDNESS_ADAPTIVE_RADIUS = 3;
+
+const COLORS = {
+  cardBackground: '#ffffff',
+  cardBorder: '#2f5f9f',
+  staleBorder: '#d23f31',
+  codeBackground: '#f5f7fb',
+  codeBorder: '#d5deea',
+  title: '#172033',
+  meta: '#59677c',
+  code: '#172033',
+  staleFill: '#fff0ed',
+  staleText: '#9b241b',
+};
+
+type CodeCardElementRole =
+  | 'container'
+  | 'codeBlock'
+  | 'title'
+  | 'metadata'
+  | 'snapshot'
+  | 'staleMarkerBackground'
+  | 'staleMarkerLabel';
+
+export type CreateCodeCardElementsOptions = {
+  x?: number;
+  y?: number;
+  updated?: number;
+};
+
+export function createCodeCardElements(
+  card: CodeCard,
+  options: CreateCodeCardElementsOptions = {},
+): ExcalidrawElementStub[] {
+  const x = options.x ?? 0;
+  const y = options.y ?? 0;
+  const updated = options.updated ?? Date.now();
+  const stale = isCodeCardStale(card);
+  const groupId = getCodeCardGroupId(card.id);
+  const codeText = formatSnapshot(card);
+  const codeTextHeight = getTextHeight(codeText, CODE_FONT_SIZE);
+  const codeHeight = Math.max(MIN_CODE_HEIGHT, codeTextHeight + CODE_PADDING * 2);
+  const height = HEADER_HEIGHT + codeHeight + CARD_PADDING * 2;
+  const codeBlockY = y + CARD_PADDING + HEADER_HEIGHT;
+  const elements: ExcalidrawElementStub[] = [
+    createRectangleElement(card, 'container', groupId, updated, {
+      x,
+      y,
+      width: CODE_CARD_WIDTH,
+      height,
+      strokeColor: stale ? COLORS.staleBorder : COLORS.cardBorder,
+      backgroundColor: COLORS.cardBackground,
+      strokeWidth: stale ? 3 : 2,
+      roughness: 0,
+    }),
+    createRectangleElement(card, 'codeBlock', groupId, updated, {
+      x: x + CARD_PADDING,
+      y: codeBlockY,
+      width: CODE_CARD_WIDTH - CARD_PADDING * 2,
+      height: codeHeight,
+      strokeColor: COLORS.codeBorder,
+      backgroundColor: COLORS.codeBackground,
+      strokeWidth: 1,
+      roughness: 0,
+    }),
+    createTextElement(card, 'title', groupId, updated, {
+      x: x + CARD_PADDING,
+      y: y + 14,
+      width: CODE_CARD_WIDTH - CARD_PADDING * 2 - (stale ? 82 : 0),
+      height: getTextHeight(formatTitle(card), TITLE_FONT_SIZE),
+      text: formatTitle(card),
+      fontSize: TITLE_FONT_SIZE,
+      strokeColor: COLORS.title,
+    }),
+    createTextElement(card, 'metadata', groupId, updated, {
+      x: x + CARD_PADDING,
+      y: y + 37,
+      width: CODE_CARD_WIDTH - CARD_PADDING * 2,
+      height: getTextHeight(formatMetadata(card), META_FONT_SIZE),
+      text: formatMetadata(card),
+      fontSize: META_FONT_SIZE,
+      strokeColor: COLORS.meta,
+    }),
+    createTextElement(card, 'snapshot', groupId, updated, {
+      x: x + CARD_PADDING + CODE_PADDING,
+      y: codeBlockY + CODE_PADDING,
+      width: CODE_CARD_WIDTH - CARD_PADDING * 2 - CODE_PADDING * 2,
+      height: codeTextHeight,
+      text: codeText,
+      fontSize: CODE_FONT_SIZE,
+      strokeColor: COLORS.code,
+    }),
+  ];
+
+  if (stale) {
+    elements.push(
+      createRectangleElement(card, 'staleMarkerBackground', groupId, updated, {
+        x: x + CODE_CARD_WIDTH - CARD_PADDING - 60,
+        y: y + 16,
+        width: 60,
+        height: 22,
+        strokeColor: COLORS.staleBorder,
+        backgroundColor: COLORS.staleFill,
+        strokeWidth: 1,
+        roughness: 0,
+      }),
+      createTextElement(card, 'staleMarkerLabel', groupId, updated, {
+        x: x + CODE_CARD_WIDTH - CARD_PADDING - 48,
+        y: y + 20,
+        width: 42,
+        height: getTextHeight('STALE', MARKER_FONT_SIZE),
+        text: 'STALE',
+        fontSize: MARKER_FONT_SIZE,
+        strokeColor: COLORS.staleText,
+      }),
+    );
+  }
+
+  return elements;
+}
+
+export function isCodeCardStale(card: CodeCard): boolean {
+  return (
+    card.customData.stale === true ||
+    card.customData.isStale === true ||
+    card.customData.status === 'stale' ||
+    readNestedBoolean(card.customData, 'codetrace', 'stale')
+  );
+}
+
+export function getCodeCardGroupId(cardId: string): string {
+  return `codetrace-card-${cardId}`;
+}
+
+function createRectangleElement(
+  card: CodeCard,
+  role: CodeCardElementRole,
+  groupId: string,
+  updated: number,
+  overrides: Partial<ExcalidrawElementStub>,
+): ExcalidrawElementStub {
+  return {
+    ...createBaseElement(card, role, groupId, updated),
+    type: 'rectangle',
+    fillStyle: 'solid',
+    strokeStyle: 'solid',
+    roundness: {
+      type: ROUNDNESS_ADAPTIVE_RADIUS,
+    },
+    ...overrides,
+  };
+}
+
+function createTextElement(
+  card: CodeCard,
+  role: CodeCardElementRole,
+  groupId: string,
+  updated: number,
+  overrides: Partial<ExcalidrawElementStub> & { text: string; fontSize: number },
+): ExcalidrawElementStub {
+  const height = overrides.height ?? getTextHeight(overrides.text, overrides.fontSize);
+
+  return {
+    ...createBaseElement(card, role, groupId, updated),
+    type: 'text',
+    backgroundColor: 'transparent',
+    fillStyle: 'solid',
+    strokeWidth: 1,
+    strokeStyle: 'solid',
+    roughness: 0,
+    roundness: null,
+    fontFamily: FONT_FAMILY_CASCADIA,
+    textAlign: 'left',
+    verticalAlign: 'top',
+    containerId: null,
+    originalText: overrides.text,
+    baseline: Math.round(Number(height) * 0.84),
+    lineHeight: TEXT_LINE_HEIGHT,
+    ...overrides,
+    height,
+  };
+}
+
+function createBaseElement(
+  card: CodeCard,
+  role: CodeCardElementRole,
+  groupId: string,
+  updated: number,
+): ExcalidrawElementStub {
+  return {
+    id: getElementId(card.id, role),
+    type: 'rectangle',
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    angle: 0,
+    strokeColor: COLORS.cardBorder,
+    backgroundColor: COLORS.cardBackground,
+    fillStyle: 'solid',
+    strokeWidth: 1,
+    strokeStyle: 'solid',
+    roughness: 1,
+    opacity: 100,
+    roundness: null,
+    seed: hashToPositiveInteger(`${card.id}:${role}:seed`),
+    version: 1,
+    versionNonce: hashToPositiveInteger(`${card.id}:${role}:versionNonce`),
+    isDeleted: false,
+    groupIds: [groupId],
+    frameId: null,
+    boundElements: null,
+    updated,
+    link: null,
+    locked: false,
+    customData: {
+      codetrace: {
+        kind: 'codeCard',
+        cardId: card.id,
+        role,
+        filePath: card.file.path,
+        range: card.range,
+        stale: isCodeCardStale(card),
+      },
+    },
+  };
+}
+
+function getElementId(cardId: string, role: CodeCardElementRole): string {
+  return `${getCodeCardGroupId(cardId)}-${role}`;
+}
+
+function formatTitle(card: CodeCard): string {
+  const range =
+    card.range.startLine === card.range.endLine
+      ? `${card.range.startLine}`
+      : `${card.range.startLine}-${card.range.endLine}`;
+
+  return truncateMiddle(`${card.file.path}:${range}`, 58);
+}
+
+function formatMetadata(card: CodeCard): string {
+  const commit = card.file.gitCommit ? ` | ${card.file.gitCommit.slice(0, 7)}` : '';
+  return truncateEnd(`${card.language}${commit}`, 70);
+}
+
+function formatSnapshot(card: CodeCard): string {
+  const sourceLines = card.snapshot.split(/\r?\n/);
+  const visibleLines = sourceLines.slice(0, MAX_CODE_LINES);
+  const lineNumberWidth = String(card.range.endLine).length;
+  const formattedLines = visibleLines.map((line, index) => {
+    const lineNumber = String(card.range.startLine + index).padStart(lineNumberWidth, ' ');
+    return `${lineNumber} | ${truncateEnd(normalizeCodeLine(line), MAX_CODE_COLUMNS)}`;
+  });
+
+  if (sourceLines.length > MAX_CODE_LINES) {
+    formattedLines.push(`${' '.repeat(lineNumberWidth)} | ...`);
+  }
+
+  return formattedLines.join('\n');
+}
+
+function normalizeCodeLine(line: string): string {
+  return line.replace(/\t/g, '  ');
+}
+
+function getTextHeight(text: string, fontSize: number): number {
+  const lines = Math.max(1, text.split('\n').length);
+  return Math.ceil(lines * fontSize * TEXT_LINE_HEIGHT);
+}
+
+function truncateEnd(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+function truncateMiddle(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+
+  const leftLength = Math.ceil((maxLength - 3) / 2);
+  const rightLength = Math.floor((maxLength - 3) / 2);
+  return `${value.slice(0, leftLength)}...${value.slice(value.length - rightLength)}`;
+}
+
+function readNestedBoolean(
+  record: Record<string, unknown>,
+  key: string,
+  nestedKey: string,
+): boolean {
+  const nested = record[key];
+  return isObjectRecord(nested) && nested[nestedKey] === true;
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hashToPositiveInteger(value: string): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+
+  return Math.abs(hash) + 1;
+}

--- a/frontend/src/codeCards/codeCardElements.ts
+++ b/frontend/src/codeCards/codeCardElements.ts
@@ -16,6 +16,16 @@ const MAX_CODE_COLUMNS = 74;
 const MIN_CODE_HEIGHT = 80;
 const FONT_FAMILY_CASCADIA = 3;
 const ROUNDNESS_ADAPTIVE_RADIUS = 3;
+const MAX_VERSION_NONCE = 0x7fffffff;
+const TITLE_OFFSET_Y = 14;
+const METADATA_OFFSET_Y = 37;
+const STALE_TITLE_WIDTH_RESERVE = 82;
+const STALE_MARKER_WIDTH = 60;
+const STALE_MARKER_HEIGHT = 22;
+const STALE_MARKER_OFFSET_Y = 16;
+const STALE_MARKER_LABEL_OFFSET_X = 12;
+const STALE_MARKER_LABEL_OFFSET_Y = 4;
+const STALE_MARKER_LABEL_WIDTH = 42;
 
 const COLORS = {
   cardBackground: '#ffffff',
@@ -82,8 +92,8 @@ export function createCodeCardElements(
     }),
     createTextElement(card, 'title', groupId, updated, {
       x: x + CARD_PADDING,
-      y: y + 14,
-      width: CODE_CARD_WIDTH - CARD_PADDING * 2 - (stale ? 82 : 0),
+      y: y + TITLE_OFFSET_Y,
+      width: CODE_CARD_WIDTH - CARD_PADDING * 2 - (stale ? STALE_TITLE_WIDTH_RESERVE : 0),
       height: getTextHeight(formatTitle(card), TITLE_FONT_SIZE),
       text: formatTitle(card),
       fontSize: TITLE_FONT_SIZE,
@@ -91,7 +101,7 @@ export function createCodeCardElements(
     }),
     createTextElement(card, 'metadata', groupId, updated, {
       x: x + CARD_PADDING,
-      y: y + 37,
+      y: y + METADATA_OFFSET_Y,
       width: CODE_CARD_WIDTH - CARD_PADDING * 2,
       height: getTextHeight(formatMetadata(card), META_FONT_SIZE),
       text: formatMetadata(card),
@@ -112,19 +122,19 @@ export function createCodeCardElements(
   if (stale) {
     elements.push(
       createRectangleElement(card, 'staleMarkerBackground', groupId, updated, {
-        x: x + CODE_CARD_WIDTH - CARD_PADDING - 60,
-        y: y + 16,
-        width: 60,
-        height: 22,
+        x: x + CODE_CARD_WIDTH - CARD_PADDING - STALE_MARKER_WIDTH,
+        y: y + STALE_MARKER_OFFSET_Y,
+        width: STALE_MARKER_WIDTH,
+        height: STALE_MARKER_HEIGHT,
         strokeColor: COLORS.staleBorder,
         backgroundColor: COLORS.staleFill,
         strokeWidth: 1,
         roughness: 0,
       }),
       createTextElement(card, 'staleMarkerLabel', groupId, updated, {
-        x: x + CODE_CARD_WIDTH - CARD_PADDING - 48,
-        y: y + 20,
-        width: 42,
+        x: x + CODE_CARD_WIDTH - CARD_PADDING - STALE_MARKER_WIDTH + STALE_MARKER_LABEL_OFFSET_X,
+        y: y + STALE_MARKER_OFFSET_Y + STALE_MARKER_LABEL_OFFSET_Y,
+        width: STALE_MARKER_LABEL_WIDTH,
         height: getTextHeight('STALE', MARKER_FONT_SIZE),
         text: 'STALE',
         fontSize: MARKER_FONT_SIZE,
@@ -222,7 +232,7 @@ function createBaseElement(
     roundness: null,
     seed: hashToPositiveInteger(`${card.id}:${role}:seed`),
     version: 1,
-    versionNonce: hashToPositiveInteger(`${card.id}:${role}:versionNonce`),
+    versionNonce: createVersionNonce(),
     isDeleted: false,
     groupIds: [groupId],
     frameId: null,
@@ -319,4 +329,8 @@ function hashToPositiveInteger(value: string): number {
   }
 
   return Math.abs(hash) + 1;
+}
+
+function createVersionNonce(): number {
+  return Math.floor(Math.random() * MAX_VERSION_NONCE) + 1;
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   define: {
+    // Excalidraw's package entrypoint reads this Node-style env flag in the browser bundle.
     'process.env.IS_PREACT': JSON.stringify('false'),
   },
   build: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    'process.env.IS_PREACT': JSON.stringify('false'),
+  },
   build: {
     outDir: '../extension/dist/webview',
     emptyOutDir: true,


### PR DESCRIPTION
﻿## Summary
- Add a CodeCard-to-Excalidraw element factory with grouped rectangles/text and CodeTrace customData metadata.
- Render incoming addCard messages into the current canvas scene and persist the updated document content.
- Show a visible STALE marker when card customData marks the snapshot stale.
- Define process.env.IS_PREACT in Vite so the Excalidraw package resolves correctly in dev/build.

## Validation
- npm.cmd test --workspace=frontend -- --runInBand
- npm.cmd run build

Closes #6
