### PR TITLE
feat(navigation): bidirectional navigation — canvas card to editor

### DIFF
--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -94,7 +94,12 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
   }
 
   private async _navigateToFile(file: unknown, startLine: unknown, endLine: unknown): Promise<void> {
-    if (typeof file !== 'string' || typeof startLine !== 'number' || typeof endLine !== 'number') {
+    if (
+      !isWorkspaceRelativePosixPath(file) ||
+      !isPositiveInteger(startLine) ||
+      !isPositiveInteger(endLine) ||
+      endLine < startLine
+    ) {
       return;
     }
 
@@ -278,4 +283,15 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     return Array.from({ length: 32 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
   }
+}
+
+function isWorkspaceRelativePosixPath(value: unknown): value is string {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  if (value.startsWith('/') || value.includes('\\')) return false;
+  const segments = value.split('/');
+  return segments.every(segment => segment !== '' && segment !== '.' && segment !== '..');
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
 }

--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -76,6 +76,8 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       } else if (msg.type === 'saveFile' && typeof msg.content === 'string') {
         await this._updateDocument(document, msg.content);
         await document.save();
+      } else if (msg.type === 'navigate') {
+        await this._navigateToFile(msg.file, msg.startLine, msg.endLine);
       }
     });
 
@@ -89,6 +91,37 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     });
 
     pushContent();
+  }
+
+  private async _navigateToFile(file: unknown, startLine: unknown, endLine: unknown): Promise<void> {
+    if (typeof file !== 'string' || typeof startLine !== 'number' || typeof endLine !== 'number') {
+      return;
+    }
+
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+      vscode.window.showErrorMessage(`CodeTrace: no workspace folder open`);
+      return;
+    }
+
+    // TODO: multi-root workspace support — currently uses the first folder only
+    const fileUri = vscode.Uri.joinPath(folders[0].uri, ...file.split('/'));
+
+    let textEditor: vscode.TextEditor;
+    try {
+      const doc = await vscode.workspace.openTextDocument(fileUri);
+      textEditor = await vscode.window.showTextDocument(doc, { preview: false });
+    } catch {
+      vscode.window.showErrorMessage(`CodeTrace: file not found in workspace: ${file}`);
+      return;
+    }
+
+    // CodeCard range is 1-based; vscode.Position is 0-based
+    const start = new vscode.Position(startLine - 1, 0);
+    const end = new vscode.Position(endLine - 1, Number.MAX_SAFE_INTEGER);
+    const range = new vscode.Range(start, end);
+    textEditor.selection = new vscode.Selection(start, end);
+    textEditor.revealRange(range, vscode.TextEditorRevealType.InCenter);
   }
 
   private async _updateDocument(document: vscode.TextDocument, content: string) {
@@ -162,6 +195,10 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
 
     window.__codetrace_saveFile = (content) => {
       vscode.postMessage({ type: 'saveFile', content });
+    };
+
+    window.__codetrace_navigate = (file, startLine, endLine) => {
+      vscode.postMessage({ type: 'navigate', file, startLine, endLine });
     };
   </script>
 `,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,7 @@ import { serializeCanvasDocument, type ExcalidrawElementStub } from './types/Can
 import type { CodeCard } from './types/CodeCard';
 import {
   getInitialDocumentContent,
+  navigateToFile,
   saveDocumentContent,
   saveDocumentFile,
   subscribeAddCard,
@@ -77,6 +78,22 @@ function getViewportSize(appState: Record<string, unknown> | undefined) {
   };
 }
 
+function getCodetraceData(customData: unknown): { cardId: string; filePath: string; range: { startLine: number; endLine: number } } | null {
+  if (typeof customData !== 'object' || customData === null) return null;
+  const ct = (customData as Record<string, unknown>).codetrace;
+  if (typeof ct !== 'object' || ct === null) return null;
+  const d = ct as Record<string, unknown>;
+  if (
+    d.kind !== 'codeCard' ||
+    typeof d.cardId !== 'string' ||
+    typeof d.filePath !== 'string' ||
+    typeof d.range !== 'object' || d.range === null
+  ) return null;
+  const range = d.range as Record<string, unknown>;
+  if (typeof range.startLine !== 'number' || typeof range.endLine !== 'number') return null;
+  return { cardId: d.cardId, filePath: d.filePath, range: { startLine: range.startLine, endLine: range.endLine } };
+}
+
 export default function App() {
   const initialDocument = useMemo(readInitialDocument, []);
   const initialContent = useMemo(() => serializeCanvasDocument(initialDocument), [initialDocument]);
@@ -85,6 +102,7 @@ export default function App() {
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
   const cardsRef = useRef<CodeCard[]>([]);
   const latestContentRef = useRef<string>(initialContent);
+  const containerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     cardsRef.current = initialDocument.cards;
@@ -100,6 +118,39 @@ export default function App() {
 
     window.addEventListener('keydown', handleSaveShortcut);
     return () => window.removeEventListener('keydown', handleSaveShortcut);
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handleMouseDown = (event: MouseEvent) => {
+      if (event.detail !== 2) return;
+
+      const api = apiRef.current;
+      if (!api) return;
+
+      const elements = api.getSceneElements();
+      const appState = api.getAppState() as unknown as Record<string, unknown>;
+      const selectedIds = appState.selectedElementIds;
+      if (typeof selectedIds !== 'object' || selectedIds === null) return;
+
+      const selectedId = Object.keys(selectedIds as Record<string, boolean>).find(
+        id => (selectedIds as Record<string, boolean>)[id],
+      );
+      if (!selectedId) return;
+
+      const hit = elements.find(el => el.id === selectedId);
+      if (!hit) return;
+
+      const ct = getCodetraceData((hit as unknown as Record<string, unknown>).customData);
+      if (!ct) return;
+
+      navigateToFile(ct.filePath, ct.range.startLine, ct.range.endLine);
+    };
+
+    container.addEventListener('mousedown', handleMouseDown, { capture: true });
+    return () => container.removeEventListener('mousedown', handleMouseDown, { capture: true });
   }, []);
 
   const applyDocumentContent = useCallback((content: string) => {
@@ -189,7 +240,7 @@ export default function App() {
   );
 
   return (
-    <div style={{ width: '100%', height: '100%' }}>
+    <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
       <Excalidraw
         excalidrawAPI={handleExcalidrawAPI}
         initialData={initialData as unknown as ExcalidrawInitialDataState}

--- a/frontend/src/vscodeBridge.test.ts
+++ b/frontend/src/vscodeBridge.test.ts
@@ -1,5 +1,6 @@
 import {
   getInitialDocumentContent,
+  navigateToFile,
   saveDocumentContent,
   saveDocumentFile,
   subscribeAddCard,
@@ -22,6 +23,7 @@ describe('vscodeBridge', () => {
     delete window.__codetrace_onAddCard;
     delete window.__codetrace_save;
     delete window.__codetrace_saveFile;
+    delete window.__codetrace_navigate;
     delete (globalThis as { window?: unknown }).window;
   });
 
@@ -61,6 +63,19 @@ describe('vscodeBridge', () => {
     saveDocumentFile('content');
 
     expect(saveFile).toHaveBeenCalledWith('content');
+  });
+
+  it('posts navigate message with file path and line range', () => {
+    const navigate = jest.fn();
+    window.__codetrace_navigate = navigate;
+
+    navigateToFile('src/index.ts', 10, 20);
+
+    expect(navigate).toHaveBeenCalledWith('src/index.ts', 10, 20);
+  });
+
+  it('does nothing when navigate hook is not registered', () => {
+    expect(() => navigateToFile('src/index.ts', 1, 1)).not.toThrow();
   });
 
   it('subscribes and restores the previous addCard handler', () => {

--- a/frontend/src/vscodeBridge.ts
+++ b/frontend/src/vscodeBridge.ts
@@ -10,6 +10,7 @@ declare global {
     __codetrace_onAddCard?: CodetraceAddCardHandler;
     __codetrace_save?: (content: string) => void;
     __codetrace_saveFile?: (content: string) => void;
+    __codetrace_navigate?: (file: string, startLine: number, endLine: number) => void;
   }
 }
 
@@ -41,4 +42,8 @@ export function subscribeAddCard(handler: CodetraceAddCardHandler): () => void {
   return () => {
     window.__codetrace_onAddCard = previousHandler;
   };
+}
+
+export function navigateToFile(file: string, startLine: number, endLine: number): void {
+  window.__codetrace_navigate?.(file, startLine, endLine);
 }


### PR DESCRIPTION
## Summary

- 캔버스 코드 카드 더블클릭 시 VS Code 에디터에서 해당 파일·라인으로 이동
- Webview: 컨테이너에 `mousedown` capture 리스너를 붙여 `detail === 2` (더블클릭)를 감지하고, Excalidraw API로 클릭된 element의 `customData.codetrace`에서 `filePath`와 `range`를 읽음
- `vscodeBridge.navigateToFile()` → `{ type: 'navigate', file, startLine, endLine }` postMessage
- Extension host: `onDidReceiveMessage`에서 `navigate` 케이스를 처리, `vscode.workspace.openTextDocument` + `showTextDocument` + `revealRange(InCenter)`
- 파일이 워크스페이스에 없는 경우 `showErrorMessage` 처리
- `CodeCard.range`는 1-based, `vscode.Position`은 0-based — `-1` 변환 적용

## Notes

- 멀티 루트 워크스페이스는 MVP에서 첫 번째 폴더만 사용 (TODO 주석 추가)
- Extension 단위 테스트는 PR #21 jest 환경 머지 후 추가 예정

## Test plan

- [ ] 프론트엔드 단위 테스트 통과 (`npm test --workspace=frontend`)
- [ ] 캔버스에서 코드 카드 더블클릭 → 에디터가 해당 파일·라인으로 이동 확인
- [ ] 워크스페이스에 없는 파일 카드 더블클릭 → 에러 메시지 표시 확인

Closes #7