### PR TITLE
[codex] Implement code card stale detection

### DIFF
--- a/extension/jest.config.cjs
+++ b/extension/jest.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/**/*.test.ts'],
+};

--- a/extension/package.json
+++ b/extension/package.json
@@ -65,6 +65,7 @@
   },
   "scripts": {
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --platform=node --format=cjs",
+    "test": "jest --passWithNoTests --config jest.config.cjs",
     "watch": "npm run build -- --watch"
   },
   "devDependencies": {

--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -10,6 +10,17 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     return CanvasEditorProvider._activePanel;
   }
 
+  static postStaleStatuses(statuses: readonly { cardId: string; stale: boolean }[]): void {
+    if (statuses.length === 0) return;
+
+    CanvasEditorProvider._panels.forEach(panel => {
+      panel.webview.postMessage({
+        type: 'staleStatus',
+        statuses,
+      });
+    });
+  }
+
   static register(context: vscode.ExtensionContext): vscode.Disposable {
     return vscode.window.registerCustomEditorProvider(
       CanvasEditorProvider.viewType,
@@ -147,12 +158,14 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     window.__codetrace_initialContent = ${this._scriptString(initialContent)};
 
     window.addEventListener('message', event => {
-      const { type, content, card } = event.data ?? {};
+      const { type, content, card, statuses } = event.data ?? {};
       if (type === 'update' && typeof content === 'string') {
         window.__codetrace_initialContent = content;
         if (window.__codetrace_onUpdate) window.__codetrace_onUpdate(content);
       } else if (type === 'addCard' && card != null) {
         if (window.__codetrace_onAddCard) window.__codetrace_onAddCard(card);
+      } else if (type === 'staleStatus' && Array.isArray(statuses)) {
+        if (window.__codetrace_onStaleStatus) window.__codetrace_onStaleStatus(statuses);
       }
     });
 

--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -15,10 +15,15 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     return Array.from(CanvasEditorProvider._documents.values());
   }
 
-  static postStaleStatuses(statuses: readonly { cardId: string; stale: boolean }[]): void {
+  static postStaleStatuses(
+    document: vscode.TextDocument,
+    statuses: readonly { cardId: string; stale: boolean }[],
+  ): void {
     if (statuses.length === 0) return;
 
-    CanvasEditorProvider._panels.forEach(panel => {
+    CanvasEditorProvider._documents.forEach((canvasDocument, panel) => {
+      if (canvasDocument.uri.toString() !== document.uri.toString()) return;
+
       panel.webview.postMessage({
         type: 'staleStatus',
         statuses,

--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -4,10 +4,15 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
   static readonly viewType = 'codetrace.canvasEditor';
 
   private static readonly _panels = new Set<vscode.WebviewPanel>();
+  private static readonly _documents = new Map<vscode.WebviewPanel, vscode.TextDocument>();
   private static _activePanel: vscode.WebviewPanel | undefined;
 
   static getActivePanel(): vscode.WebviewPanel | undefined {
     return CanvasEditorProvider._activePanel;
+  }
+
+  static getOpenCanvasDocuments(): vscode.TextDocument[] {
+    return Array.from(CanvasEditorProvider._documents.values());
   }
 
   static postStaleStatuses(statuses: readonly { cardId: string; stale: boolean }[]): void {
@@ -39,6 +44,7 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     webviewPanel: vscode.WebviewPanel,
   ): Promise<void> {
     CanvasEditorProvider._panels.add(webviewPanel);
+    CanvasEditorProvider._documents.set(webviewPanel, document);
     CanvasEditorProvider._activePanel = webviewPanel;
 
     webviewPanel.onDidChangeViewState(() => {
@@ -94,6 +100,7 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       changeSubscription.dispose();
       saveSubscription.dispose();
       CanvasEditorProvider._panels.delete(webviewPanel);
+      CanvasEditorProvider._documents.delete(webviewPanel);
       if (CanvasEditorProvider._activePanel === webviewPanel) {
         CanvasEditorProvider._activePanel = undefined;
       }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { CanvasEditorProvider } from './CanvasEditorProvider';
 import { CodeAnalyzer } from './CodeAnalyzer';
+import { getStaleStatusesForPath, parseCanvasCodeCards } from './staleDetection';
 import { generateUlid } from './ulid';
 
 
@@ -10,6 +11,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(outputChannel);
 
   context.subscriptions.push(CanvasEditorProvider.register(context));
+  context.subscriptions.push(registerStaleDetection());
 
   context.subscriptions.push(
     vscode.commands.registerCommand('codetrace.analyzeRelationships', async () => {
@@ -258,6 +260,44 @@ export function activate(context: vscode.ExtensionContext) {
       panel.webview.postMessage({ type: 'addCard', card });
     })
   );
+}
+
+function registerStaleDetection(): vscode.Disposable {
+  return vscode.workspace.onDidChangeTextDocument(event => {
+    const filePath = getWorkspaceRelativePosixPath(event.document.uri);
+    if (!filePath) return;
+
+    const currentLines = getDocumentLines(event.document);
+    const statuses = vscode.workspace.textDocuments.flatMap(document => {
+      if (!isCanvasDocument(document)) return [];
+
+      return getStaleStatusesForPath(
+        parseCanvasCodeCards(document.getText()),
+        filePath,
+        currentLines,
+      );
+    });
+
+    CanvasEditorProvider.postStaleStatuses(statuses);
+  });
+}
+
+function getWorkspaceRelativePosixPath(uri: vscode.Uri): string | undefined {
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+  if (!workspaceFolder) return undefined;
+
+  return uri.fsPath
+    .slice(workspaceFolder.uri.fsPath.length)
+    .replace(/^[/\\]/, '')
+    .replace(/\\/g, '/');
+}
+
+function getDocumentLines(document: vscode.TextDocument): string[] {
+  return Array.from({ length: document.lineCount }, (_value, index) => document.lineAt(index).text);
+}
+
+function isCanvasDocument(document: vscode.TextDocument): boolean {
+  return document.languageId === 'codetrace' || document.uri.fsPath.endsWith('.codetrace');
 }
 
 export function deactivate() {}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -268,15 +268,13 @@ function registerStaleDetection(): vscode.Disposable {
     if (!filePath) return;
 
     const currentLines = getDocumentLines(event.document);
-    const statuses = vscode.workspace.textDocuments.flatMap(document => {
-      if (!isCanvasDocument(document)) return [];
-
-      return getStaleStatusesForPath(
+    const statuses = CanvasEditorProvider.getOpenCanvasDocuments().flatMap(document =>
+      getStaleStatusesForPath(
         parseCanvasCodeCards(document.getText()),
         filePath,
         currentLines,
-      );
-    });
+      ),
+    );
 
     CanvasEditorProvider.postStaleStatuses(statuses);
   });
@@ -294,10 +292,6 @@ function getWorkspaceRelativePosixPath(uri: vscode.Uri): string | undefined {
 
 function getDocumentLines(document: vscode.TextDocument): string[] {
   return Array.from({ length: document.lineCount }, (_value, index) => document.lineAt(index).text);
-}
-
-function isCanvasDocument(document: vscode.TextDocument): boolean {
-  return document.languageId === 'codetrace' || document.uri.fsPath.endsWith('.codetrace');
 }
 
 export function deactivate() {}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -268,15 +268,15 @@ function registerStaleDetection(): vscode.Disposable {
     if (!filePath) return;
 
     const currentLines = getDocumentLines(event.document);
-    const statuses = CanvasEditorProvider.getOpenCanvasDocuments().flatMap(document =>
-      getStaleStatusesForPath(
+    CanvasEditorProvider.getOpenCanvasDocuments().forEach(document => {
+      const statuses = getStaleStatusesForPath(
         parseCanvasCodeCards(document.getText()),
         filePath,
         currentLines,
-      ),
-    );
+      );
 
-    CanvasEditorProvider.postStaleStatuses(statuses);
+      CanvasEditorProvider.postStaleStatuses(document, statuses);
+    });
   });
 }
 

--- a/extension/src/staleDetection.test.ts
+++ b/extension/src/staleDetection.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from '@jest/globals';
+import { getStaleStatusesForPath, parseCanvasCodeCards } from './staleDetection';
+
+const card = {
+  id: 'card-1',
+  file: {
+    path: 'src/example.ts',
+  },
+  range: {
+    startLine: 2,
+    endLine: 3,
+  },
+  snapshot: 'const value = 1;\nconsole.log(value);',
+};
+
+describe('staleDetection', () => {
+  it('parses code cards from a canvas document', () => {
+    expect(
+      parseCanvasCodeCards(
+        JSON.stringify({
+          version: 1,
+          elements: [],
+          cards: [card, { id: 'invalid' }],
+        }),
+      ),
+    ).toEqual([card]);
+  });
+
+  it('returns an empty card list for invalid canvas content', () => {
+    expect(parseCanvasCodeCards('not json')).toEqual([]);
+    expect(parseCanvasCodeCards(JSON.stringify({ version: 1, cards: 'nope' }))).toEqual([]);
+  });
+
+  it('marks a card fresh when the current file lines match the snapshot', () => {
+    expect(
+      getStaleStatusesForPath([card], 'src/example.ts', [
+        'import value from "./value";',
+        'const value = 1;',
+        'console.log(value);',
+      ]),
+    ).toEqual([{ cardId: 'card-1', stale: false }]);
+  });
+
+  it('marks a card stale when the current file lines differ', () => {
+    expect(
+      getStaleStatusesForPath([card], 'src/example.ts', [
+        'import value from "./value";',
+        'const value = 2;',
+        'console.log(value);',
+      ]),
+    ).toEqual([{ cardId: 'card-1', stale: true }]);
+  });
+
+  it('marks a card stale when the tracked range is outside the current file', () => {
+    expect(getStaleStatusesForPath([card], 'src/example.ts', ['const value = 1;'])).toEqual([
+      { cardId: 'card-1', stale: true },
+    ]);
+  });
+
+  it('ignores cards for other files', () => {
+    expect(
+      getStaleStatusesForPath([card], 'src/other.ts', [
+        'import value from "./value";',
+        'const value = 1;',
+        'console.log(value);',
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/extension/src/staleDetection.ts
+++ b/extension/src/staleDetection.ts
@@ -1,0 +1,72 @@
+export type CodeCardSnapshot = {
+  id: string;
+  file: {
+    path: string;
+  };
+  range: {
+    startLine: number;
+    endLine: number;
+  };
+  snapshot: string;
+};
+
+export type CodeCardStaleStatus = {
+  cardId: string;
+  stale: boolean;
+};
+
+export function parseCanvasCodeCards(content: string): CodeCardSnapshot[] {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return [];
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.cards)) return [];
+  return parsed.cards.filter(isCodeCardSnapshot);
+}
+
+export function getStaleStatusesForPath(
+  cards: readonly CodeCardSnapshot[],
+  filePath: string,
+  currentLines: readonly string[],
+): CodeCardStaleStatus[] {
+  return cards
+    .filter(card => card.file.path === filePath)
+    .map(card => ({
+      cardId: card.id,
+      stale: readSnapshot(currentLines, card.range.startLine, card.range.endLine) !== card.snapshot,
+    }));
+}
+
+function readSnapshot(
+  lines: readonly string[],
+  startLine: number,
+  endLine: number,
+): string | undefined {
+  if (startLine < 1 || endLine < startLine || endLine > lines.length) return undefined;
+  return lines.slice(startLine - 1, endLine).join('\n');
+}
+
+function isCodeCardSnapshot(value: unknown): value is CodeCardSnapshot {
+  if (!isRecord(value)) return false;
+
+  const file = value.file;
+  const range = value.range;
+
+  return (
+    typeof value.id === 'string' &&
+    isRecord(file) &&
+    typeof file.path === 'string' &&
+    isRecord(range) &&
+    Number.isInteger(range.startLine) &&
+    Number.isInteger(range.endLine) &&
+    typeof value.snapshot === 'string'
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,12 @@ import type {
   ExcalidrawImperativeAPI,
   ExcalidrawInitialDataState,
 } from '@excalidraw/excalidraw/types/types';
-import { CODE_CARD_WIDTH, createCodeCardElements } from './codeCards/codeCardElements';
+import {
+  CODE_CARD_WIDTH,
+  createCodeCardElements,
+  isCodeCardStale,
+  replaceCodeCardElements,
+} from './codeCards/codeCardElements';
 import {
   createCanvasDocumentFromScene,
   parseCanvasDocumentContent,
@@ -23,6 +28,8 @@ import {
   saveDocumentFile,
   subscribeAddCard,
   subscribeDocumentUpdates,
+  subscribeStaleStatus,
+  type CodeCardStaleStatus,
 } from './vscodeBridge';
 
 type ExcalidrawChangeHandler = NonNullable<ComponentProps<typeof Excalidraw>['onChange']>;
@@ -75,6 +82,54 @@ function getViewportSize(appState: Record<string, unknown> | undefined) {
     width: window.innerWidth || fallbackWidth,
     height: window.innerHeight || fallbackHeight,
   };
+}
+
+function applyStaleStatusesToCards(
+  cards: readonly CodeCard[],
+  statuses: readonly CodeCardStaleStatus[],
+): { cards: CodeCard[]; changed: boolean } {
+  const staleByCardId = new Map(statuses.map(status => [status.cardId, status.stale]));
+  let changed = false;
+
+  const nextCards = cards.map(card => {
+    const stale = staleByCardId.get(card.id);
+    if (stale === undefined || isCodeCardStale(card) === stale) return card;
+
+    changed = true;
+    return {
+      ...card,
+      customData: updateStaleCustomData(card.customData, stale),
+    };
+  });
+
+  return { cards: nextCards, changed };
+}
+
+function updateStaleCustomData(
+  customData: Record<string, unknown>,
+  stale: boolean,
+): Record<string, unknown> {
+  const nextCustomData: Record<string, unknown> = {
+    ...customData,
+    stale,
+  };
+
+  if (nextCustomData.status === 'stale') {
+    delete nextCustomData.status;
+  }
+
+  if (isRecord(nextCustomData.codetrace)) {
+    nextCustomData.codetrace = {
+      ...nextCustomData.codetrace,
+      stale,
+    };
+  }
+
+  return nextCustomData;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 export default function App() {
@@ -165,6 +220,52 @@ export default function App() {
   }, []);
 
   useEffect(() => subscribeAddCard(handleAddCard), [handleAddCard]);
+
+  const handleStaleStatus = useCallback((statuses: CodeCardStaleStatus[]) => {
+    const updated = applyStaleStatusesToCards(cardsRef.current, statuses);
+    if (!updated.changed) return;
+
+    cardsRef.current = updated.cards;
+
+    const api = apiRef.current;
+    let elements = api ? (api.getSceneElements() as unknown as ExcalidrawElementStub[]) : [];
+    let appState = api ? (api.getAppState() as unknown as Record<string, unknown>) : undefined;
+    let files = api ? (api.getFiles() as unknown as Record<string, unknown>) : undefined;
+
+    if (api) {
+      const affectedCardIds = new Set(statuses.map(status => status.cardId));
+      const nextElements = updated.cards.reduce((sceneElements, card, index) => {
+        if (!affectedCardIds.has(card.id)) return sceneElements;
+
+        return replaceCodeCardElements(
+          sceneElements,
+          card,
+          getNextCodeCardPosition(appState, index),
+        );
+      }, elements);
+
+      api.updateScene({
+        elements: nextElements as unknown as ExcalidrawElement[],
+        commitToHistory: false,
+      });
+
+      elements = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+      appState = api.getAppState() as unknown as Record<string, unknown>;
+      files = api.getFiles() as unknown as Record<string, unknown>;
+    }
+
+    const document = createCanvasDocumentFromScene({
+      elements,
+      appState,
+      files,
+      cards: updated.cards,
+    });
+    const content = serializeCanvasDocument(document);
+    latestContentRef.current = content;
+    saveDocumentContent(content);
+  }, []);
+
+  useEffect(() => subscribeStaleStatus(handleStaleStatus), [handleStaleStatus]);
 
   const handleExcalidrawAPI = useCallback((api: ExcalidrawImperativeAPI) => {
     apiRef.current = api;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import type {
 import {
   CODE_CARD_WIDTH,
   createCodeCardElements,
+  hasCodeCardContainer,
   isCodeCardStale,
   replaceCodeCardElements,
 } from './codeCards/codeCardElements';
@@ -114,6 +115,9 @@ function updateStaleCustomData(
     ...customData,
     stale,
   };
+
+  // Keep customData.stale canonical while clearing legacy aliases that isCodeCardStale accepts.
+  delete nextCustomData.isStale;
 
   if (nextCustomData.status === 'stale') {
     delete nextCustomData.status;
@@ -287,6 +291,7 @@ export default function App() {
       const affectedCardIds = new Set(statuses.map(status => status.cardId));
       const nextElements = updated.cards.reduce((sceneElements, card, index) => {
         if (!affectedCardIds.has(card.id)) return sceneElements;
+        if (!hasCodeCardContainer(sceneElements, card.id)) return sceneElements;
 
         return replaceCodeCardElements(
           sceneElements,

--- a/frontend/src/codeCards/codeCardElements.test.ts
+++ b/frontend/src/codeCards/codeCardElements.test.ts
@@ -2,6 +2,7 @@ import type { CodeCard } from '../types/CodeCard';
 import {
   createCodeCardElements,
   getCodeCardGroupId,
+  hasCodeCardContainer,
   isCodeCardStale,
   replaceCodeCardElements,
 } from './codeCardElements';
@@ -118,6 +119,14 @@ describe('codeCardElements', () => {
     expect(container.x).toBe(320);
     expect(container.y).toBe(180);
     expect(staleElements).toHaveLength(2);
+  });
+
+  it('detects whether the scene contains a card container', () => {
+    const elements = createCodeCardElements(card, { x: 100, y: 200, updated: 123 });
+
+    expect(hasCodeCardContainer(elements, card.id)).toBe(true);
+    expect(hasCodeCardContainer(elements, 'missing-card')).toBe(false);
+    expect(hasCodeCardContainer([{ id: 'plain', type: 'rectangle' }], card.id)).toBe(false);
   });
 
   it('accepts nested codetrace stale metadata for future update flows', () => {

--- a/frontend/src/codeCards/codeCardElements.test.ts
+++ b/frontend/src/codeCards/codeCardElements.test.ts
@@ -1,5 +1,10 @@
 import type { CodeCard } from '../types/CodeCard';
-import { createCodeCardElements, getCodeCardGroupId, isCodeCardStale } from './codeCardElements';
+import {
+  createCodeCardElements,
+  getCodeCardGroupId,
+  isCodeCardStale,
+  replaceCodeCardElements,
+} from './codeCardElements';
 
 const card: CodeCard = {
   id: '01ARZ3NDEKTSV4RRFFQ69G5FAV',
@@ -88,6 +93,31 @@ describe('codeCardElements', () => {
         stale: true,
       },
     });
+  });
+
+  it('replaces an existing card group in place when stale status changes', () => {
+    const unrelatedElement = { id: 'unrelated', type: 'rectangle' };
+    const staleCard: CodeCard = {
+      ...card,
+      customData: {
+        stale: true,
+      },
+    };
+    const elements = [
+      unrelatedElement,
+      ...createCodeCardElements(card, { x: 320, y: 180, updated: 123 }),
+    ];
+
+    const nextElements = replaceCodeCardElements(elements, staleCard, { x: 10, y: 20 });
+    const container = getElementByRole(nextElements, 'container');
+    const staleElements = nextElements.filter(element =>
+      String(getCustomData(element).role).startsWith('staleMarker'),
+    );
+
+    expect(nextElements[0]).toBe(unrelatedElement);
+    expect(container.x).toBe(320);
+    expect(container.y).toBe(180);
+    expect(staleElements).toHaveLength(2);
   });
 
   it('accepts nested codetrace stale metadata for future update flows', () => {

--- a/frontend/src/codeCards/codeCardElements.ts
+++ b/frontend/src/codeCards/codeCardElements.ts
@@ -165,6 +165,16 @@ export function getCodeCardGroupId(cardId: string): string {
   return `codetrace-card-${cardId}`;
 }
 
+export function hasCodeCardContainer(
+  elements: readonly ExcalidrawElementStub[],
+  cardId: string,
+): boolean {
+  return elements.some(element => {
+    const metadata = readCodeCardElementMetadata(element);
+    return metadata?.cardId === cardId && metadata.role === 'container';
+  });
+}
+
 export function replaceCodeCardElements(
   elements: readonly ExcalidrawElementStub[],
   card: CodeCard,

--- a/frontend/src/codeCards/codeCardElements.ts
+++ b/frontend/src/codeCards/codeCardElements.ts
@@ -49,6 +49,12 @@ type CodeCardElementRole =
   | 'staleMarkerBackground'
   | 'staleMarkerLabel';
 
+type CodeCardElementMetadata = {
+  kind: 'codeCard';
+  cardId: string;
+  role: CodeCardElementRole;
+};
+
 export type CreateCodeCardElementsOptions = {
   x?: number;
   y?: number;
@@ -159,6 +165,44 @@ export function getCodeCardGroupId(cardId: string): string {
   return `codetrace-card-${cardId}`;
 }
 
+export function replaceCodeCardElements(
+  elements: readonly ExcalidrawElementStub[],
+  card: CodeCard,
+  fallbackPosition: { x: number; y: number },
+): ExcalidrawElementStub[] {
+  let insertIndex = -1;
+  let position = fallbackPosition;
+  const retainedElements: ExcalidrawElementStub[] = [];
+
+  elements.forEach(element => {
+    const metadata = readCodeCardElementMetadata(element);
+    if (metadata?.cardId !== card.id) {
+      retainedElements.push(element);
+      return;
+    }
+
+    if (insertIndex === -1) {
+      insertIndex = retainedElements.length;
+    }
+
+    if (metadata.role === 'container') {
+      position = {
+        x: readNumber(element.x, fallbackPosition.x),
+        y: readNumber(element.y, fallbackPosition.y),
+      };
+    }
+  });
+
+  const nextCardElements = createCodeCardElements(card, position);
+  const safeInsertIndex = insertIndex === -1 ? retainedElements.length : insertIndex;
+
+  return [
+    ...retainedElements.slice(0, safeInsertIndex),
+    ...nextCardElements,
+    ...retainedElements.slice(safeInsertIndex),
+  ];
+}
+
 function createRectangleElement(
   card: CodeCard,
   role: CodeCardElementRole,
@@ -176,6 +220,40 @@ function createRectangleElement(
     },
     ...overrides,
   };
+}
+
+function readCodeCardElementMetadata(
+  element: ExcalidrawElementStub,
+): CodeCardElementMetadata | undefined {
+  if (!isObjectRecord(element.customData)) return undefined;
+
+  const codetrace = element.customData.codetrace;
+  if (!isObjectRecord(codetrace)) return undefined;
+  if (codetrace.kind !== 'codeCard') return undefined;
+  if (typeof codetrace.cardId !== 'string') return undefined;
+  if (!isCodeCardElementRole(codetrace.role)) return undefined;
+
+  return {
+    kind: 'codeCard',
+    cardId: codetrace.cardId,
+    role: codetrace.role,
+  };
+}
+
+function isCodeCardElementRole(value: unknown): value is CodeCardElementRole {
+  return (
+    value === 'container' ||
+    value === 'codeBlock' ||
+    value === 'title' ||
+    value === 'metadata' ||
+    value === 'snapshot' ||
+    value === 'staleMarkerBackground' ||
+    value === 'staleMarkerLabel'
+  );
+}
+
+function readNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
 }
 
 function createTextElement(

--- a/frontend/src/vscodeBridge.test.ts
+++ b/frontend/src/vscodeBridge.test.ts
@@ -4,6 +4,7 @@ import {
   saveDocumentFile,
   subscribeAddCard,
   subscribeDocumentUpdates,
+  subscribeStaleStatus,
 } from './vscodeBridge';
 import type { CodeCard } from './types/CodeCard';
 
@@ -20,6 +21,7 @@ describe('vscodeBridge', () => {
     delete window.__codetrace_initialContent;
     delete window.__codetrace_onUpdate;
     delete window.__codetrace_onAddCard;
+    delete window.__codetrace_onStaleStatus;
     delete window.__codetrace_save;
     delete window.__codetrace_saveFile;
     delete (globalThis as { window?: unknown }).window;
@@ -84,5 +86,20 @@ describe('vscodeBridge', () => {
 
     expect(next).toHaveBeenCalledWith(card);
     expect(previous).toHaveBeenCalledWith(card);
+  });
+
+  it('subscribes and restores the previous stale status handler', () => {
+    const statuses = [{ cardId: '01JVMH2N8S7T3K4P6Q8X9Y0Z12', stale: true }];
+    const previous = jest.fn();
+    const next = jest.fn();
+    window.__codetrace_onStaleStatus = previous;
+
+    const unsubscribe = subscribeStaleStatus(next);
+    window.__codetrace_onStaleStatus?.(statuses);
+    unsubscribe();
+    window.__codetrace_onStaleStatus?.(statuses);
+
+    expect(next).toHaveBeenCalledWith(statuses);
+    expect(previous).toHaveBeenCalledWith(statuses);
   });
 });

--- a/frontend/src/vscodeBridge.ts
+++ b/frontend/src/vscodeBridge.ts
@@ -2,12 +2,18 @@ import type { CodeCard } from './types/CodeCard';
 
 export type CodetraceUpdateHandler = (content: string) => void;
 export type CodetraceAddCardHandler = (card: CodeCard) => void;
+export type CodeCardStaleStatus = {
+  cardId: string;
+  stale: boolean;
+};
+export type CodetraceStaleStatusHandler = (statuses: CodeCardStaleStatus[]) => void;
 
 declare global {
   interface Window {
     __codetrace_initialContent?: string;
     __codetrace_onUpdate?: CodetraceUpdateHandler;
     __codetrace_onAddCard?: CodetraceAddCardHandler;
+    __codetrace_onStaleStatus?: CodetraceStaleStatusHandler;
     __codetrace_save?: (content: string) => void;
     __codetrace_saveFile?: (content: string) => void;
   }
@@ -40,5 +46,14 @@ export function subscribeAddCard(handler: CodetraceAddCardHandler): () => void {
 
   return () => {
     window.__codetrace_onAddCard = previousHandler;
+  };
+}
+
+export function subscribeStaleStatus(handler: CodetraceStaleStatusHandler): () => void {
+  const previousHandler = window.__codetrace_onStaleStatus;
+  window.__codetrace_onStaleStatus = handler;
+
+  return () => {
+    window.__codetrace_onStaleStatus = previousHandler;
   };
 }


### PR DESCRIPTION
﻿## Summary

- Extension Host에서 열린 `.codetrace` 문서의 코드 카드 snapshot을 현재 파일 라인 텍스트와 비교합니다.
- 파일 변경 시 카드별 stale 상태를 webview로 전달하는 `staleStatus` 메시지를 추가합니다.
- 프론트엔드에서 카드 위치를 유지한 채 stale marker를 켜고 끄도록 CodeCard element 교체 로직을 추가합니다.
- stale 메시지 구독과 카드 element 교체 흐름에 대한 단위 테스트를 보강합니다.

## Validation

- npm.cmd test --workspace=frontend -- --runInBand
- npm.cmd run build

Closes #15
