### PR TITLE
fix(frontend): emit relative asset paths for webview CSS

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  // Webview serves assets from a vscode-resource URI, so emit relative asset paths.
+  base: './',
   define: {
     // Excalidraw's package entrypoint reads this Node-style env flag in the browser bundle.
     'process.env.IS_PREACT': JSON.stringify('false'),


### PR DESCRIPTION
## Summary
- Vite 기본 `base: '/'`가 빌드 CSS에 `url(/assets/...)` 절대 경로를 생성 → webview에서 401 발생
- `base: './'`로 변경하여 CSS `url()`이 stylesheet 위치 기준 상대 경로로 해석되도록 수정
- 결과: 번들된 4개 woff2 폰트가 정상 로드됨

## #45 진행 상황
- 401 / `url()` 절대 경로 문제: **이 PR로 해소**
- 남은 문제: Excalidraw 0.18 런타임이 `https://esm.sh/@excalidraw/excalidraw@<ver>/...`에서 추가 폰트(서브셋)를 fetch → CSP `font-src` 위반. **별도 후속 이슈로 처리** (캔버스 전환 검토 중이라 우선순위 보류 가능)

## Test plan
- [ ] `npm run build --workspace=frontend`
- [ ] 빌드 산출 CSS의 url() 확인: `url(./Assistant-*.woff2)`
- [ ] Extension Development Host에서 401 에러 사라짐을 콘솔로 확인