### PR TITLE
feat(extension): TS Compiler API 단일 파일 호출 그래프 PoC (#48)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -69,6 +69,9 @@
     "watch": "npm run build -- --watch",
     "test": "npm run build && tsc -p ./ && vscode-test"
   },
+  "dependencies": {
+    "typescript": "^5.3.0"
+  },
   "devDependencies": {
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.0.0",
@@ -76,7 +79,6 @@
     "@vscode/test-cli": "^0.0.4",
     "@vscode/test-electron": "^2.3.8",
     "esbuild": "^0.20.0",
-    "mocha": "^10.2.0",
-    "typescript": "^5.3.0"
+    "mocha": "^10.2.0"
   }
 }

--- a/extension/src/analyzer/__fixtures__/sample.ts
+++ b/extension/src/analyzer/__fixtures__/sample.ts
@@ -1,0 +1,28 @@
+// Fixture for callGraph.test.ts: 5 function-like nodes, 3 calls.
+// greet  -> helper          (function -> function)
+// sayHi  -> greet            (arrow    -> function)
+// Service.run -> Service.runInner (method -> method via this)
+
+export function greet(name: string): string {
+  return helper(name);
+}
+
+const sayHi = (name: string) => {
+  return greet(name);
+};
+
+class Service {
+  public run(name: string): string {
+    return this.runInner(name);
+  }
+
+  private runInner(name: string): string {
+    return name;
+  }
+}
+
+function helper(input: string): string {
+  return input.toUpperCase();
+}
+
+export { sayHi, Service };

--- a/extension/src/analyzer/__fixtures__/unresolved.ts
+++ b/extension/src/analyzer/__fixtures__/unresolved.ts
@@ -1,0 +1,31 @@
+// Negative fixture: receivers that cannot be statically attributed must NOT
+// produce edges to unrelated methods that share a name.
+// Asserted in callGraph.test.ts.
+
+class Service {
+  run(): string {
+    return 'service';
+  }
+}
+
+class Worker {
+  run(): string {
+    return 'worker';
+  }
+}
+
+// Param receiver: 'obj' is untyped here, so the call site below is ambiguous.
+function caller(obj: { run(): string }): string {
+  return obj.run();
+}
+
+// Return-value receiver: also unresolvable from a single-file pass.
+function build(): Service {
+  return new Service();
+}
+
+function viaReturn(): string {
+  return build().run();
+}
+
+export { Service, Worker, caller, viaReturn };

--- a/extension/src/analyzer/callGraph.test.ts
+++ b/extension/src/analyzer/callGraph.test.ts
@@ -56,3 +56,34 @@ describe('extractCallGraph (single file)', () => {
     expect(idsB).toEqual(idsA);
   });
 });
+
+describe('extractCallGraph — unresolved receivers', () => {
+  const unresolvedPath = path.join(__dirname, '__fixtures__', 'unresolved.ts');
+  const graph = extractCallGraph(unresolvedPath);
+
+  test('caller(obj).obj.run() does not create any outbound edge', () => {
+    const callerNode = graph.nodes.find(n => n.name === 'caller')!;
+    const callerSources = graph.edges.filter(e => e.from === callerNode.id);
+    expect(callerSources).toEqual([]);
+  });
+
+  test('viaReturn() only edges to build, never to .run() target', () => {
+    // viaReturn() calls build() (resolvable) and build().run() (NOT resolvable).
+    // We expect exactly one outbound edge: viaReturn → build.
+    const viaReturnNode = graph.nodes.find(n => n.name === 'viaReturn')!;
+    const buildNode = graph.nodes.find(n => n.name === 'build')!;
+    const outbound = graph.edges
+      .filter(e => e.from === viaReturnNode.id)
+      .map(e => graph.nodes.find(n => n.id === e.to)?.name);
+
+    expect(outbound).toEqual([buildNode.name]);
+  });
+
+  test('Service.run / Worker.run never appear as edge targets in this fixture', () => {
+    const targets = graph.edges.map(e => {
+      return graph.nodes.find(n => n.id === e.to)?.name;
+    });
+    expect(targets).not.toContain('Service.run');
+    expect(targets).not.toContain('Worker.run');
+  });
+});

--- a/extension/src/analyzer/callGraph.test.ts
+++ b/extension/src/analyzer/callGraph.test.ts
@@ -1,0 +1,58 @@
+import * as path from 'path';
+import { extractCallGraph } from './callGraph';
+
+const fixturePath = path.join(__dirname, '__fixtures__', 'sample.ts');
+
+describe('extractCallGraph (single file)', () => {
+  const graph = extractCallGraph(fixturePath);
+
+  test('extracts 5 function-like nodes (function, arrow, two methods, helper)', () => {
+    const names = graph.nodes.map(n => n.name).sort();
+    expect(names).toEqual(['Service.run', 'Service.runInner', 'greet', 'helper', 'sayHi']);
+  });
+
+  test('classifies node kinds', () => {
+    const kindByName = Object.fromEntries(graph.nodes.map(n => [n.name, n.kind]));
+    expect(kindByName).toEqual({
+      greet: 'function',
+      sayHi: 'arrow',
+      'Service.run': 'method',
+      'Service.runInner': 'method',
+      helper: 'function',
+    });
+  });
+
+  test('records the three intra-file calls (greet→helper, sayHi→greet, run→runInner)', () => {
+    const idByName = Object.fromEntries(graph.nodes.map(n => [n.name, n.id]));
+    const pairs = graph.edges.map(e => {
+      const fromName = graph.nodes.find(n => n.id === e.from)?.name;
+      const toName = graph.nodes.find(n => n.id === e.to)?.name;
+      return `${fromName}->${toName}`;
+    }).sort();
+    expect(pairs).toEqual([
+      'Service.run->Service.runInner',
+      'greet->helper',
+      'sayHi->greet',
+    ]);
+
+    // ids are well-formed (no orphan edges)
+    for (const edge of graph.edges) {
+      expect(Object.values(idByName)).toContain(edge.from);
+      expect(Object.values(idByName)).toContain(edge.to);
+    }
+  });
+
+  test('node ranges are 1-based and contain the declaration', () => {
+    const greet = graph.nodes.find(n => n.name === 'greet')!;
+    expect(greet.range.startLine).toBeGreaterThan(0);
+    expect(greet.range.endLine).toBeGreaterThanOrEqual(greet.range.startLine);
+    expect(greet.file).toBe(fixturePath);
+  });
+
+  test('node IDs are stable across repeated extraction', () => {
+    const again = extractCallGraph(fixturePath);
+    const idsA = graph.nodes.map(n => n.id).sort();
+    const idsB = again.nodes.map(n => n.id).sort();
+    expect(idsB).toEqual(idsA);
+  });
+});

--- a/extension/src/analyzer/callGraph.ts
+++ b/extension/src/analyzer/callGraph.ts
@@ -135,15 +135,17 @@ function resolveCallee(
       }
     }
 
-    // `Class.method()` — try qualified match first.
+    // `Class.method()` — qualified match against the receiver identifier.
     if (ts.isIdentifier(expression.expression)) {
       const qualified = `${expression.expression.text}.${methodName}`;
-      const exact = nodes.find(n => n.name === qualified);
-      if (exact) return exact;
+      return nodes.find(n => n.name === qualified);
     }
 
-    // Fallback: any method node ending with `.methodName` (still local to file).
-    return nodes.find(n => n.kind === 'method' && n.name.endsWith(`.${methodName}`));
+    // Receivers we can't statically attribute (parameters, returns, calls, etc.)
+    // are intentionally not matched: a name-only fallback would create
+    // false-positive edges to unrelated methods that happen to share a name.
+    // Cross-file/typed resolution will land in #53.
+    return undefined;
   }
 
   return undefined;

--- a/extension/src/analyzer/callGraph.ts
+++ b/extension/src/analyzer/callGraph.ts
@@ -1,0 +1,150 @@
+import * as fs from 'fs';
+import * as ts from 'typescript';
+import type { CallEdge, CallGraph, FunctionKind, FunctionNode, SourceRange } from './types';
+
+export function extractCallGraph(filePath: string): CallGraph {
+  const source = fs.readFileSync(filePath, 'utf8');
+  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
+
+  const nodes: FunctionNode[] = [];
+  const nodeIdByDecl = new Map<ts.Node, string>();
+  const edges: CallEdge[] = [];
+
+  // First pass: collect every function-like declaration with a stable name.
+  const collectScope = (parentName: string | undefined) => (node: ts.Node) => {
+    if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+      const className = node.name?.text ?? parentName ?? 'anonymous';
+      ts.forEachChild(node, collectScope(className));
+      return;
+    }
+
+    const declared = describeFunction(node, parentName);
+    if (declared) {
+      const id = makeId(filePath, declared.name, declared.range);
+      nodes.push({ id, name: declared.name, kind: declared.kind, file: filePath, range: declared.range });
+      nodeIdByDecl.set(declared.declNode, id);
+    }
+    ts.forEachChild(node, collectScope(parentName));
+  };
+  ts.forEachChild(sourceFile, collectScope(undefined));
+
+  // Second pass: for each call expression, attribute it to the enclosing function node.
+  const visitCall = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const callerId = enclosingFunctionId(node, nodeIdByDecl);
+      const callee = resolveCallee(node.expression, nodes, callerId);
+      if (callerId && callee) {
+        edges.push({ from: callerId, to: callee.id });
+      }
+    }
+    ts.forEachChild(node, visitCall);
+  };
+  ts.forEachChild(sourceFile, visitCall);
+
+  return { nodes, edges };
+}
+
+interface FunctionDescriptor {
+  name: string;
+  kind: FunctionKind;
+  range: SourceRange;
+  declNode: ts.Node;
+}
+
+function describeFunction(node: ts.Node, parentName: string | undefined): FunctionDescriptor | undefined {
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return {
+      name: node.name.text,
+      kind: 'function',
+      range: rangeOf(node),
+      declNode: node,
+    };
+  }
+
+  if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
+    const owner = parentName ?? 'anonymous';
+    return {
+      name: `${owner}.${node.name.text}`,
+      kind: 'method',
+      range: rangeOf(node),
+      declNode: node,
+    };
+  }
+
+  if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
+    const init = node.initializer;
+    if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
+      return {
+        name: node.name.text,
+        kind: ts.isArrowFunction(init) ? 'arrow' : 'function',
+        range: rangeOf(init),
+        declNode: init,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function rangeOf(node: ts.Node): SourceRange {
+  const sourceFile = node.getSourceFile();
+  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd());
+  return {
+    startLine: start.line + 1,
+    startColumn: start.character + 1,
+    endLine: end.line + 1,
+    endColumn: end.character + 1,
+  };
+}
+
+function makeId(filePath: string, name: string, range: SourceRange): string {
+  return `${filePath}#${name}@${range.startLine}:${range.startColumn}`;
+}
+
+function enclosingFunctionId(node: ts.Node, nodeIdByDecl: Map<ts.Node, string>): string | undefined {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    const id = nodeIdByDecl.get(current);
+    if (id) return id;
+    current = current.parent;
+  }
+  return undefined;
+}
+
+function resolveCallee(
+  expression: ts.Expression,
+  nodes: FunctionNode[],
+  callerId: string | undefined,
+): FunctionNode | undefined {
+  if (ts.isIdentifier(expression)) {
+    return nodes.find(n => n.name === expression.text);
+  }
+
+  if (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.name)) {
+    const methodName = expression.name.text;
+
+    // `this.method()` — resolve within the same class as the caller.
+    if (expression.expression.kind === ts.SyntaxKind.ThisKeyword && callerId) {
+      const caller = nodes.find(n => n.id === callerId);
+      const className = caller?.kind === 'method' ? caller.name.split('.')[0] : undefined;
+      if (className) {
+        const qualified = `${className}.${methodName}`;
+        const exact = nodes.find(n => n.name === qualified);
+        if (exact) return exact;
+      }
+    }
+
+    // `Class.method()` — try qualified match first.
+    if (ts.isIdentifier(expression.expression)) {
+      const qualified = `${expression.expression.text}.${methodName}`;
+      const exact = nodes.find(n => n.name === qualified);
+      if (exact) return exact;
+    }
+
+    // Fallback: any method node ending with `.methodName` (still local to file).
+    return nodes.find(n => n.kind === 'method' && n.name.endsWith(`.${methodName}`));
+  }
+
+  return undefined;
+}

--- a/extension/src/analyzer/types.ts
+++ b/extension/src/analyzer/types.ts
@@ -1,0 +1,26 @@
+export type FunctionKind = 'function' | 'method' | 'arrow';
+
+export interface SourceRange {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}
+
+export interface FunctionNode {
+  id: string;
+  name: string;
+  kind: FunctionKind;
+  file: string;
+  range: SourceRange;
+}
+
+export interface CallEdge {
+  from: string;
+  to: string;
+}
+
+export interface CallGraph {
+  nodes: FunctionNode[];
+  edges: CallEdge[];
+}

--- a/extension/src/test/suite/callGraph.test.ts
+++ b/extension/src/test/suite/callGraph.test.ts
@@ -1,0 +1,64 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { extractCallGraph } from '../../analyzer/callGraph';
+
+// __dirname at runtime is `out/test/suite/`, but the fixture is a .ts source file
+// kept under `src/`. Resolve back to the workspace src tree.
+const fixturePath = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'src',
+  'analyzer',
+  '__fixtures__',
+  'sample.ts',
+);
+
+suite('extractCallGraph (single file)', () => {
+  const graph = extractCallGraph(fixturePath);
+
+  test('extracts five function-like nodes', () => {
+    const names = graph.nodes.map(n => n.name).sort();
+    assert.deepStrictEqual(names, [
+      'Service.run',
+      'Service.runInner',
+      'greet',
+      'helper',
+      'sayHi',
+    ]);
+  });
+
+  test('classifies node kinds', () => {
+    const kindByName = Object.fromEntries(graph.nodes.map(n => [n.name, n.kind]));
+    assert.deepStrictEqual(kindByName, {
+      greet: 'function',
+      sayHi: 'arrow',
+      'Service.run': 'method',
+      'Service.runInner': 'method',
+      helper: 'function',
+    });
+  });
+
+  test('records the three intra-file calls', () => {
+    const pairs = graph.edges
+      .map(e => {
+        const fromName = graph.nodes.find(n => n.id === e.from)?.name;
+        const toName = graph.nodes.find(n => n.id === e.to)?.name;
+        return `${fromName}->${toName}`;
+      })
+      .sort();
+    assert.deepStrictEqual(pairs, [
+      'Service.run->Service.runInner',
+      'greet->helper',
+      'sayHi->greet',
+    ]);
+  });
+
+  test('node IDs are stable across repeated extraction', () => {
+    const again = extractCallGraph(fixturePath);
+    const idsA = graph.nodes.map(n => n.id).sort();
+    const idsB = again.nodes.map(n => n.id).sort();
+    assert.deepStrictEqual(idsB, idsA);
+  });
+});

--- a/extension/src/test/suite/callGraph.test.ts
+++ b/extension/src/test/suite/callGraph.test.ts
@@ -62,3 +62,43 @@ suite('extractCallGraph (single file)', () => {
     assert.deepStrictEqual(idsB, idsA);
   });
 });
+
+suite('extractCallGraph — unresolved receivers', () => {
+  const unresolvedPath = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'src',
+    'analyzer',
+    '__fixtures__',
+    'unresolved.ts',
+  );
+  const graph = extractCallGraph(unresolvedPath);
+
+  test('caller(obj).obj.run() does not create any outbound edge', () => {
+    const callerNode = graph.nodes.find(n => n.name === 'caller');
+    assert.ok(callerNode, 'caller node missing');
+    const outbound = graph.edges.filter(e => e.from === callerNode!.id);
+    assert.deepStrictEqual(outbound, []);
+  });
+
+  test('viaReturn() only edges to build, never to .run() target', () => {
+    const viaReturnNode = graph.nodes.find(n => n.name === 'viaReturn');
+    const buildNode = graph.nodes.find(n => n.name === 'build');
+    assert.ok(viaReturnNode, 'viaReturn node missing');
+    assert.ok(buildNode, 'build node missing');
+
+    const outbound = graph.edges
+      .filter(e => e.from === viaReturnNode!.id)
+      .map(e => graph.nodes.find(n => n.id === e.to)?.name);
+
+    assert.deepStrictEqual(outbound, [buildNode!.name]);
+  });
+
+  test('Service.run / Worker.run never appear as edge targets', () => {
+    const targets = graph.edges.map(e => graph.nodes.find(n => n.id === e.to)?.name);
+    assert.ok(!targets.includes('Service.run'));
+    assert.ok(!targets.includes('Worker.run'));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
     "extension": {
       "name": "codetrace",
       "version": "0.1.0",
+      "dependencies": {
+        "typescript": "^5.3.0"
+      },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^20.0.0",
@@ -25,8 +28,7 @@
         "@vscode/test-cli": "^0.0.4",
         "@vscode/test-electron": "^2.3.8",
         "esbuild": "^0.20.0",
-        "mocha": "^10.2.0",
-        "typescript": "^5.3.0"
+        "mocha": "^10.2.0"
       },
       "engines": {
         "vscode": "^1.85.0"
@@ -12439,7 +12441,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
Resolves #48

## Summary
- \`extension/src/analyzer/\`에 \`extractCallGraph(filePath)\` 구현
- 같은 파일 내 함수 선언(function/arrow/method)과 호출 관계 추출
- \`this.method()\` 및 \`Class.method()\` 호출 해석
- typescript를 \`devDependencies\` → \`dependencies\`로 이동 (런타임 사용)

## 데이터 모델 (\`analyzer/types.ts\`)
- \`FunctionNode\`: id / name / kind('function'|'method'|'arrow') / file / range
- \`CallEdge\`: from → to (FunctionNode.id 참조)
- \`CallGraph\`: { nodes, edges }

## 테스트
- jest 단위 테스트 (\`src/analyzer/callGraph.test.ts\`) — 로컬 빠른 피드백
- mocha 단위 테스트 (\`src/test/suite/callGraph.test.ts\`) — vscode-test 환경 (CI \`npm test --workspace=extension\`이 잡음)
- 픽스처: 함수 5개 / 호출 3개 (\`__fixtures__/sample.ts\`)

## Out of scope (별도 이슈)
- Cross-file resolution → #53
- 클래스 상속, generic, 외부 import → 후속

## Test plan
- [ ] \`npx jest src/analyzer\` (extension 디렉터리에서) — 5개 통과
- [ ] CI에서 mocha vscode-test 잡 통과
- [ ] \`npx tsc -p extension\` 컴파일 에러 없음