### PR TITLE
feat(frontend): React Flow + dagre 자동 레이아웃 캔버스 보일러플레이트 (#49)

### DIFF
--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -16,6 +16,9 @@ module.exports = {
       testEnvironment: 'jsdom',
       testMatch: ['<rootDir>/src/**/*.dom.test.tsx'],
       setupFilesAfterEnv: ['<rootDir>/src/test/setupTests.ts'],
+      moduleNameMapper: {
+        '\\.(css|less|scss|sass)$': '<rootDir>/src/test/styleMock.cjs',
+      },
     },
   ],
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,9 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@excalidraw/excalidraw": "^0.18.1",
+    "@xyflow/react": "^12.10.2",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "yjs": "^13.6.30"

--- a/frontend/src/graph/CallGraphCanvas.css
+++ b/frontend/src/graph/CallGraphCanvas.css
@@ -1,0 +1,90 @@
+.codetrace-canvas {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.codetrace-canvas__toolbar {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 5;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.codetrace-canvas__toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #1f2937;
+}
+
+.codetrace-canvas__toolbar select {
+  font-size: 12px;
+  padding: 2px 4px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+
+.codetrace-fn-node {
+  width: 220px;
+  min-height: 64px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #c7d2fe;
+  background: #ffffff;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.1);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  color: #111827;
+}
+
+.codetrace-fn-node[data-codetrace-kind='method'] {
+  border-color: #fbbf24;
+}
+
+.codetrace-fn-node[data-codetrace-kind='arrow'] {
+  border-color: #34d399;
+}
+
+.codetrace-fn-node__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.codetrace-fn-node__name {
+  font-weight: 600;
+  font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.codetrace-fn-node__kind {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b7280;
+  background: #f3f4f6;
+  padding: 2px 6px;
+  border-radius: 999px;
+}
+
+.codetrace-fn-node__file {
+  margin-top: 4px;
+  font-size: 11px;
+  color: #6b7280;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  direction: rtl;
+  text-align: left;
+}

--- a/frontend/src/graph/CallGraphCanvas.dom.test.tsx
+++ b/frontend/src/graph/CallGraphCanvas.dom.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, within } from '@testing-library/react';
+import { CallGraphCanvas } from './CallGraphCanvas';
+import { SAMPLE_GRAPH } from './__demo__/sampleGraph';
+
+// React Flow needs container size to render; jsdom returns 0 by default.
+// Stub ResizeObserver and getBoundingClientRect for the test surface.
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverMock }).ResizeObserver =
+    ResizeObserverMock;
+
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({ width: 1200, height: 800, top: 0, left: 0, right: 1200, bottom: 800, x: 0, y: 0, toJSON: () => ({}) }),
+  });
+
+  // React Flow uses DOMMatrixReadOnly for transforms; jsdom omits it.
+  if (typeof (globalThis as { DOMMatrixReadOnly?: unknown }).DOMMatrixReadOnly === 'undefined') {
+    (globalThis as { DOMMatrixReadOnly: unknown }).DOMMatrixReadOnly = class {
+      m22 = 1;
+      constructor() {}
+    };
+  }
+});
+
+describe('CallGraphCanvas', () => {
+  test('renders all sample nodes via custom node component', () => {
+    const { container } = render(<CallGraphCanvas graph={SAMPLE_GRAPH} />);
+
+    const rendered = container.querySelectorAll('.codetrace-fn-node');
+    expect(rendered.length).toBe(SAMPLE_GRAPH.nodes.length);
+
+    for (const node of SAMPLE_GRAPH.nodes) {
+      // function name should be visible in at least one custom node
+      expect(screen.getAllByText(node.name).length).toBeGreaterThan(0);
+    }
+  });
+
+  test('renders the layout direction toolbar', () => {
+    render(<CallGraphCanvas graph={SAMPLE_GRAPH} />);
+    const select = screen.getByLabelText(/layout/i) as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    const options = within(select).getAllByRole('option').map(o => (o as HTMLOptionElement).value);
+    expect(options).toEqual(['TB', 'LR']);
+  });
+});

--- a/frontend/src/graph/CallGraphCanvas.tsx
+++ b/frontend/src/graph/CallGraphCanvas.tsx
@@ -1,0 +1,73 @@
+import {
+  Background,
+  Controls,
+  MiniMap,
+  ReactFlow,
+  type Edge,
+  type Node,
+  type NodeTypes,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import { useMemo, useState } from 'react';
+import { FunctionNodeView, type FunctionNodeData } from './FunctionNodeView';
+import { layoutCallGraph } from './layout';
+import type { CallGraph, LayoutDirection } from './types';
+import './CallGraphCanvas.css';
+
+const NODE_TYPES: NodeTypes = {
+  function: FunctionNodeView,
+};
+
+export interface CallGraphCanvasProps {
+  graph: CallGraph;
+  initialDirection?: LayoutDirection;
+}
+
+export function CallGraphCanvas({ graph, initialDirection = 'TB' }: CallGraphCanvasProps) {
+  const [direction, setDirection] = useState<LayoutDirection>(initialDirection);
+
+  const { nodes, edges } = useMemo(() => {
+    const baseNodes: Node<FunctionNodeData>[] = graph.nodes.map(n => ({
+      id: n.id,
+      type: 'function',
+      position: { x: 0, y: 0 },
+      data: { name: n.name, kind: n.kind, file: n.file },
+    }));
+
+    const baseEdges: Edge[] = graph.edges.map(e => ({
+      id: `${e.from}->${e.to}`,
+      source: e.from,
+      target: e.to,
+    }));
+
+    return layoutCallGraph(baseNodes, baseEdges, { direction });
+  }, [graph, direction]);
+
+  return (
+    <div className="codetrace-canvas">
+      <div className="codetrace-canvas__toolbar">
+        <label>
+          Layout
+          <select
+            value={direction}
+            onChange={e => setDirection(e.target.value as LayoutDirection)}
+          >
+            <option value="TB">Top → Bottom</option>
+            <option value="LR">Left → Right</option>
+          </select>
+        </label>
+      </div>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={NODE_TYPES}
+        fitView
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background />
+        <MiniMap pannable zoomable />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/frontend/src/graph/CallGraphCanvas.tsx
+++ b/frontend/src/graph/CallGraphCanvas.tsx
@@ -3,7 +3,6 @@ import {
   Controls,
   MiniMap,
   ReactFlow,
-  type Edge,
   type Node,
   type NodeTypes,
 } from '@xyflow/react';
@@ -11,6 +10,7 @@ import '@xyflow/react/dist/style.css';
 import { useMemo, useState } from 'react';
 import { FunctionNodeView, type FunctionNodeData } from './FunctionNodeView';
 import { layoutCallGraph } from './layout';
+import { toReactFlowEdges } from './graphAdapter';
 import type { CallGraph, LayoutDirection } from './types';
 import './CallGraphCanvas.css';
 
@@ -34,11 +34,7 @@ export function CallGraphCanvas({ graph, initialDirection = 'TB' }: CallGraphCan
       data: { name: n.name, kind: n.kind, file: n.file },
     }));
 
-    const baseEdges: Edge[] = graph.edges.map(e => ({
-      id: `${e.from}->${e.to}`,
-      source: e.from,
-      target: e.to,
-    }));
+    const baseEdges = toReactFlowEdges(graph.edges);
 
     return layoutCallGraph(baseNodes, baseEdges, { direction });
   }, [graph, direction]);

--- a/frontend/src/graph/FunctionNodeView.tsx
+++ b/frontend/src/graph/FunctionNodeView.tsx
@@ -1,0 +1,31 @@
+import { Handle, Position, type NodeProps } from '@xyflow/react';
+import type { FunctionKind } from './types';
+
+export interface FunctionNodeData extends Record<string, unknown> {
+  name: string;
+  kind: FunctionKind;
+  file: string;
+}
+
+const KIND_LABEL: Record<FunctionKind, string> = {
+  function: 'fn',
+  method: 'method',
+  arrow: 'arrow',
+};
+
+export function FunctionNodeView({ data }: NodeProps) {
+  const { name, kind, file } = data as FunctionNodeData;
+  return (
+    <div className="codetrace-fn-node" data-codetrace-kind={kind}>
+      <Handle type="target" position={Position.Top} />
+      <div className="codetrace-fn-node__header">
+        <span className="codetrace-fn-node__name">{name}</span>
+        <span className="codetrace-fn-node__kind">{KIND_LABEL[kind]}</span>
+      </div>
+      <div className="codetrace-fn-node__file" title={file}>
+        {file}
+      </div>
+      <Handle type="source" position={Position.Bottom} />
+    </div>
+  );
+}

--- a/frontend/src/graph/__demo__/sampleGraph.ts
+++ b/frontend/src/graph/__demo__/sampleGraph.ts
@@ -1,0 +1,49 @@
+import type { CallGraph } from '../types';
+
+// Demo data shaped to match what extension/src/analyzer produces.
+// Used by App.tsx until the messaging flow (#50) wires real analysis results.
+export const SAMPLE_GRAPH: CallGraph = {
+  nodes: [
+    {
+      id: 'demo#greet',
+      name: 'greet',
+      kind: 'function',
+      file: 'src/sample.ts',
+      range: { startLine: 1, startColumn: 1, endLine: 3, endColumn: 2 },
+    },
+    {
+      id: 'demo#sayHi',
+      name: 'sayHi',
+      kind: 'arrow',
+      file: 'src/sample.ts',
+      range: { startLine: 5, startColumn: 1, endLine: 7, endColumn: 2 },
+    },
+    {
+      id: 'demo#Service.run',
+      name: 'Service.run',
+      kind: 'method',
+      file: 'src/sample.ts',
+      range: { startLine: 10, startColumn: 3, endLine: 12, endColumn: 4 },
+    },
+    {
+      id: 'demo#Service.runInner',
+      name: 'Service.runInner',
+      kind: 'method',
+      file: 'src/sample.ts',
+      range: { startLine: 14, startColumn: 3, endLine: 16, endColumn: 4 },
+    },
+    {
+      id: 'demo#helper',
+      name: 'helper',
+      kind: 'function',
+      file: 'src/sample.ts',
+      range: { startLine: 18, startColumn: 1, endLine: 20, endColumn: 2 },
+    },
+  ],
+  edges: [
+    { from: 'demo#greet', to: 'demo#helper' },
+    { from: 'demo#sayHi', to: 'demo#greet' },
+    { from: 'demo#Service.run', to: 'demo#Service.runInner' },
+    { from: 'demo#sayHi', to: 'demo#Service.run' },
+  ],
+};

--- a/frontend/src/graph/graphAdapter.test.ts
+++ b/frontend/src/graph/graphAdapter.test.ts
@@ -1,0 +1,41 @@
+import { toReactFlowEdges } from './graphAdapter';
+import type { CallEdge } from './types';
+
+describe('toReactFlowEdges', () => {
+  test('collapses duplicate (from, to) pairs into a single edge', () => {
+    const input: CallEdge[] = [
+      { from: 'a', to: 'b' },
+      { from: 'a', to: 'b' }, // same pair (e.g., foo() calls helper() twice)
+      { from: 'a', to: 'b' },
+    ];
+    const edges = toReactFlowEdges(input);
+    expect(edges).toHaveLength(1);
+    expect(edges[0]).toEqual({ id: 'a->b', source: 'a', target: 'b' });
+  });
+
+  test('keeps distinct edges and preserves first-seen order', () => {
+    const input: CallEdge[] = [
+      { from: 'a', to: 'b' },
+      { from: 'a', to: 'c' },
+      { from: 'a', to: 'b' }, // dup of #1
+      { from: 'b', to: 'c' },
+    ];
+    const edges = toReactFlowEdges(input);
+    expect(edges.map(e => e.id)).toEqual(['a->b', 'a->c', 'b->c']);
+  });
+
+  test('produces unique React Flow edge ids', () => {
+    const input: CallEdge[] = [
+      { from: 'x', to: 'y' },
+      { from: 'x', to: 'y' },
+      { from: 'y', to: 'x' },
+    ];
+    const edges = toReactFlowEdges(input);
+    const ids = edges.map(e => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test('returns an empty array for empty input', () => {
+    expect(toReactFlowEdges([])).toEqual([]);
+  });
+});

--- a/frontend/src/graph/graphAdapter.ts
+++ b/frontend/src/graph/graphAdapter.ts
@@ -1,0 +1,26 @@
+import type { Edge } from '@xyflow/react';
+import type { CallEdge } from './types';
+
+/**
+ * Convert analyzer call edges into React Flow edges, collapsing duplicates.
+ *
+ * The analyzer emits one edge per call expression, so a function calling the
+ * same callee multiple times produces several `{ from, to }` records. React
+ * Flow uses edge id as identity; passing duplicate ids triggers warnings and
+ * causes one of the edges to be dropped or have its state cross-contaminated.
+ *
+ * For visualization the relation "A calls B" is what matters, not the call
+ * count. We dedupe by `(from, to)` here. If call counts become a UI need,
+ * attach them as edge data without changing the id strategy.
+ */
+export function toReactFlowEdges(callEdges: readonly CallEdge[]): Edge[] {
+  const seen = new Set<string>();
+  const out: Edge[] = [];
+  for (const e of callEdges) {
+    const key = `${e.from}->${e.to}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ id: key, source: e.from, target: e.to });
+  }
+  return out;
+}

--- a/frontend/src/graph/layout.test.ts
+++ b/frontend/src/graph/layout.test.ts
@@ -1,0 +1,58 @@
+import type { Edge, Node } from '@xyflow/react';
+import { layoutCallGraph } from './layout';
+
+interface DemoData extends Record<string, unknown> {
+  label: string;
+}
+
+function makeNodes(ids: string[]): Node<DemoData>[] {
+  return ids.map(id => ({
+    id,
+    position: { x: 0, y: 0 },
+    data: { label: id },
+  }));
+}
+
+function makeEdges(pairs: [string, string][]): Edge[] {
+  return pairs.map(([source, target]) => ({ id: `${source}->${target}`, source, target }));
+}
+
+describe('layoutCallGraph', () => {
+  test('positions every node and preserves edges', () => {
+    const nodes = makeNodes(['a', 'b', 'c']);
+    const edges = makeEdges([
+      ['a', 'b'],
+      ['a', 'c'],
+    ]);
+
+    const result = layoutCallGraph(nodes, edges);
+
+    expect(result.nodes).toHaveLength(3);
+    expect(result.edges).toEqual(edges);
+
+    const positions = Object.fromEntries(result.nodes.map(n => [n.id, n.position]));
+    // root above its children with default TB direction
+    expect(positions.a.y).toBeLessThan(positions.b.y);
+    expect(positions.a.y).toBeLessThan(positions.c.y);
+  });
+
+  test('LR direction lays children to the right', () => {
+    const nodes = makeNodes(['root', 'leaf']);
+    const edges = makeEdges([['root', 'leaf']]);
+
+    const { nodes: laid } = layoutCallGraph(nodes, edges, { direction: 'LR' });
+    const map = Object.fromEntries(laid.map(n => [n.id, n.position]));
+
+    expect(map.leaf.x).toBeGreaterThan(map.root.x);
+  });
+
+  test('keeps disconnected nodes (no edge into the dagre graph)', () => {
+    const nodes = makeNodes(['x', 'y']);
+    const { nodes: laid } = layoutCallGraph(nodes, []);
+    expect(laid.map(n => n.id).sort()).toEqual(['x', 'y']);
+    for (const node of laid) {
+      expect(typeof node.position.x).toBe('number');
+      expect(typeof node.position.y).toBe('number');
+    }
+  });
+});

--- a/frontend/src/graph/layout.ts
+++ b/frontend/src/graph/layout.ts
@@ -1,0 +1,54 @@
+import dagre from '@dagrejs/dagre';
+import type { Edge, Node } from '@xyflow/react';
+import type { LayoutDirection } from './types';
+
+export interface LayoutOptions {
+  direction?: LayoutDirection;
+  nodeWidth?: number;
+  nodeHeight?: number;
+  rankSep?: number;
+  nodeSep?: number;
+}
+
+const DEFAULTS: Required<LayoutOptions> = {
+  direction: 'TB',
+  nodeWidth: 220,
+  nodeHeight: 64,
+  rankSep: 80,
+  nodeSep: 32,
+};
+
+export function layoutCallGraph<NodeData extends Record<string, unknown>>(
+  nodes: Node<NodeData>[],
+  edges: Edge[],
+  options: LayoutOptions = {},
+): { nodes: Node<NodeData>[]; edges: Edge[] } {
+  const { direction, nodeWidth, nodeHeight, rankSep, nodeSep } = { ...DEFAULTS, ...options };
+
+  const graph = new dagre.graphlib.Graph();
+  graph.setDefaultEdgeLabel(() => ({}));
+  graph.setGraph({ rankdir: direction, ranksep: rankSep, nodesep: nodeSep });
+
+  for (const node of nodes) {
+    graph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+  }
+  for (const edge of edges) {
+    graph.setEdge(edge.source, edge.target);
+  }
+
+  dagre.layout(graph);
+
+  const positionedNodes = nodes.map(node => {
+    const { x, y } = graph.node(node.id);
+    // dagre returns center coordinates; React Flow expects top-left.
+    return {
+      ...node,
+      position: { x: x - nodeWidth / 2, y: y - nodeHeight / 2 },
+      // Hint to React Flow about node sizing for connector routing.
+      width: nodeWidth,
+      height: nodeHeight,
+    };
+  });
+
+  return { nodes: positionedNodes, edges };
+}

--- a/frontend/src/graph/types.ts
+++ b/frontend/src/graph/types.ts
@@ -1,0 +1,32 @@
+// Mirrors the analyzer types in extension/src/analyzer/types.ts.
+// Duplicated to keep the frontend independent of the extension package import path.
+// When messaging is wired in #50, both ends will agree on this shape.
+
+export type FunctionKind = 'function' | 'method' | 'arrow';
+
+export interface SourceRange {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}
+
+export interface FunctionNode {
+  id: string;
+  name: string;
+  kind: FunctionKind;
+  file: string;
+  range: SourceRange;
+}
+
+export interface CallEdge {
+  from: string;
+  to: string;
+}
+
+export interface CallGraph {
+  nodes: FunctionNode[];
+  edges: CallEdge[];
+}
+
+export type LayoutDirection = 'TB' | 'LR';

--- a/frontend/src/test/setupTests.ts
+++ b/frontend/src/test/setupTests.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom';
+
+// jsdom (jest-environment-jsdom 29) does not expose structuredClone, but
+// dagre relies on it. Polyfill from Node's global if available.
+if (typeof (globalThis as { structuredClone?: unknown }).structuredClone !== 'function') {
+  (globalThis as { structuredClone: typeof structuredClone }).structuredClone = (value: unknown) =>
+    JSON.parse(JSON.stringify(value));
+}

--- a/frontend/src/test/styleMock.cjs
+++ b/frontend/src/test/styleMock.cjs
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,9 @@
       "name": "codetrace-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@excalidraw/excalidraw": "^0.18.1",
+        "@xyflow/react": "^12.10.2",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
         "yjs": "^13.6.30"
@@ -2850,6 +2852,21 @@
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -5662,6 +5679,38 @@
         "node": ">=10"
       }
     },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -6231,6 +6280,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",


### PR DESCRIPTION
Resolves #49

## Summary
- \`@xyflow/react\`(React Flow 12) + \`@dagrejs/dagre\` 추가
- \`frontend/src/graph/\` 모듈 신설:
  - \`CallGraphCanvas\` — 메인 캔버스 (TB/LR 토글, 미니맵, 줌/팬, 컨트롤)
  - \`FunctionNodeView\` — 커스텀 함수 노드 (이름·종류 배지·파일 경로)
  - \`layout.ts\` — dagre 기반 \`layoutCallGraph\` 유틸
  - \`types.ts\` — 분석기와 동일한 \`FunctionNode\`/\`CallEdge\`/\`CallGraph\` 모양 (#50에서 메시지 타입으로 통합 예정)
  - \`__demo__/sampleGraph.ts\` — 5노드/4엣지 더미

## 테스트 인프라 변경
- \`jest.config.cjs\`: jsdom 프로젝트에 \`moduleNameMapper\`로 css 무시
- \`setupTests.ts\`: jsdom 환경에서 \`structuredClone\` 폴리필 (dagre가 사용)

## Out of scope
- App.tsx에서 실제 노출하는 통합은 #50 (메시지 흐름)에서 함께 처리
- 노드 클릭 → 에디터 점프는 #51
- 사이드바는 #54
- Excalidraw 기존 코드 정리는 #60 결정 후

## Test plan
- [ ] \`cd frontend && npx jest src/graph\` → 5 통과
- [ ] \`cd frontend && npx jest\` → 44 통과 (회귀 없음)
- [ ] \`npm run build --workspace=frontend\` → 성공