### PR TITLE
refactor(messaging): extension↔webview 호출 그래프 메시지 흐름 신설 (#50)

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -34,6 +34,10 @@
       {
         "command": "codetrace.addSelectionToCanvas",
         "title": "CodeTrace: Add Selection to Canvas"
+      },
+      {
+        "command": "codetrace.openCallGraph",
+        "title": "CodeTrace: Open Call Graph"
       }
     ],
     "menus": {

--- a/extension/src/callGraph/CallGraphPanel.ts
+++ b/extension/src/callGraph/CallGraphPanel.ts
@@ -1,0 +1,178 @@
+import * as vscode from 'vscode';
+import { extractCallGraph } from '../analyzer/callGraph';
+import type { CallGraph } from '../analyzer/types';
+import type {
+  ExtensionToWebviewMessage,
+  WebviewToExtensionMessage,
+} from './messages';
+
+export class CallGraphPanel {
+  static readonly viewType = 'codetrace.callGraph';
+  private static current: CallGraphPanel | undefined;
+
+  static createOrShow(context: vscode.ExtensionContext): CallGraphPanel {
+    const column = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.One;
+    if (CallGraphPanel.current) {
+      CallGraphPanel.current.panel.reveal(column);
+      return CallGraphPanel.current;
+    }
+
+    const panel = vscode.window.createWebviewPanel(
+      CallGraphPanel.viewType,
+      'CodeTrace Call Graph',
+      column,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'dist')],
+      },
+    );
+
+    CallGraphPanel.current = new CallGraphPanel(panel, context);
+    return CallGraphPanel.current;
+  }
+
+  private constructor(
+    private readonly panel: vscode.WebviewPanel,
+    private readonly context: vscode.ExtensionContext,
+  ) {
+    this.panel.onDidDispose(() => {
+      if (CallGraphPanel.current === this) {
+        CallGraphPanel.current = undefined;
+      }
+    });
+
+    this.panel.webview.onDidReceiveMessage(async (msg: WebviewToExtensionMessage) => {
+      if (!msg || typeof msg !== 'object') return;
+      if (msg.type === 'requestRefresh') {
+        await this.analyzeAndPost();
+      } else if (msg.type === 'nodeClick') {
+        // Navigation lands in #51; for now just ignore.
+        return;
+      }
+    });
+
+    this.bootstrap().catch(err => {
+      console.error('CodeTrace: failed to load call graph webview', err);
+    });
+  }
+
+  async analyzeActiveFile(): Promise<void> {
+    await this.analyzeAndPost();
+  }
+
+  private async bootstrap(): Promise<void> {
+    try {
+      this.panel.webview.html = await this.getHtml();
+    } catch (error) {
+      console.error('CodeTrace: failed to load call graph webview assets', error);
+      this.panel.webview.html = this.getFallbackHtml(
+        'CodeTrace webview build is missing. Run `npm run build --workspace=frontend` and reopen the call graph.',
+      );
+      vscode.window.showErrorMessage(
+        'CodeTrace: webview build is missing. Run `npm run build --workspace=frontend`.',
+      );
+      return;
+    }
+
+    await this.analyzeAndPost();
+  }
+
+  private async analyzeAndPost(): Promise<void> {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      this.post({ type: 'analysisError', message: '활성 에디터가 없습니다. .ts 파일을 열고 다시 시도하세요.' });
+      return;
+    }
+
+    const fsPath = editor.document.uri.fsPath;
+    if (!/\.(ts|tsx)$/.test(fsPath)) {
+      this.post({ type: 'analysisError', message: 'TypeScript 파일(.ts, .tsx)만 분석할 수 있습니다.' });
+      return;
+    }
+
+    let graph: CallGraph;
+    try {
+      graph = extractCallGraph(fsPath);
+    } catch (err) {
+      this.post({
+        type: 'analysisError',
+        message: `분석 중 오류: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+
+    this.post({ type: 'analysisResult', graph });
+  }
+
+  private post(message: ExtensionToWebviewMessage): void {
+    this.panel.webview.postMessage(message);
+  }
+
+  private async getHtml(): Promise<string> {
+    const nonce = randomNonce();
+    const webview = this.panel.webview;
+    const webviewRoot = vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'webview');
+    const indexUri = vscode.Uri.joinPath(webviewRoot, 'callgraph.html');
+    const html = new TextDecoder().decode(await vscode.workspace.fs.readFile(indexUri));
+
+    const csp = [
+      `default-src 'none'`,
+      `style-src ${webview.cspSource} 'unsafe-inline'`,
+      `script-src 'nonce-${nonce}' ${webview.cspSource}`,
+      `img-src ${webview.cspSource} data: blob:`,
+      `font-src ${webview.cspSource}`,
+      `connect-src ${webview.cspSource}`,
+    ].join('; ');
+
+    return rewriteWebviewUris(html, webview, webviewRoot)
+      .replace(
+        '<head>',
+        `<head>\n  <meta http-equiv="Content-Security-Policy" content="${csp}" />`,
+      )
+      .replace(/<script(\s)/g, `<script nonce="${nonce}"$1`)
+      .replace(
+        '<body>',
+        `<body>\n  <script nonce="${nonce}">window.__codetrace_vscode = acquireVsCodeApi();</script>`,
+      );
+  }
+
+  private getFallbackHtml(message: string): string {
+    const csp = [`default-src 'none'`, `style-src 'unsafe-inline'`].join('; ');
+    return `<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="UTF-8" />
+<meta http-equiv="Content-Security-Policy" content="${csp}" />
+<title>CodeTrace Call Graph</title>
+<style>body{font-family:system-ui,sans-serif;padding:24px;color:#1f2937;}code{background:#eef2ff;padding:2px 6px;border-radius:4px;}</style>
+</head><body><h2>CodeTrace Call Graph</h2><p>${escapeHtml(message)}</p><p><code>npm run build --workspace=frontend</code></p></body></html>`;
+  }
+}
+
+function rewriteWebviewUris(html: string, webview: vscode.Webview, webviewRoot: vscode.Uri): string {
+  return html.replace(/\b(src|href)="([^"]+)"/g, (_match, attribute: string, resourcePath: string) => {
+    if (/^(?:[a-z][a-z0-9+.-]*:|#|\/\/)/i.test(resourcePath)) {
+      return `${attribute}="${resourcePath}"`;
+    }
+    const normalizedPath = resourcePath.replace(/^\.?\//, '').replace(/^\/+/, '');
+    if (!normalizedPath || normalizedPath.startsWith('..')) {
+      return `${attribute}="${resourcePath}"`;
+    }
+    const resourceUri = vscode.Uri.joinPath(webviewRoot, ...normalizedPath.split('/'));
+    return `${attribute}="${webview.asWebviewUri(resourceUri)}"`;
+  });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function randomNonce(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  return Array.from({ length: 32 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+}

--- a/extension/src/callGraph/CallGraphPanel.ts
+++ b/extension/src/callGraph/CallGraphPanel.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-import { extractCallGraph } from '../analyzer/callGraph';
-import type { CallGraph } from '../analyzer/types';
+import { buildAnalysisMessage } from './buildAnalysisMessage';
 import type {
   ExtensionToWebviewMessage,
   WebviewToExtensionMessage,
@@ -10,10 +9,20 @@ export class CallGraphPanel {
   static readonly viewType = 'codetrace.callGraph';
   private static current: CallGraphPanel | undefined;
 
-  static createOrShow(context: vscode.ExtensionContext): CallGraphPanel {
+  /**
+   * Creates the panel if needed, then analyzes `targetUri`. Pass the URI
+   * captured at command-invocation time — once the webview takes focus,
+   * `vscode.window.activeTextEditor` becomes undefined, so reading it later
+   * (e.g., on Refresh from the webview) loses the analysis target.
+   */
+  static async createOrShow(
+    context: vscode.ExtensionContext,
+    targetUri: vscode.Uri | undefined,
+  ): Promise<CallGraphPanel> {
     const column = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.One;
     if (CallGraphPanel.current) {
       CallGraphPanel.current.panel.reveal(column);
+      await CallGraphPanel.current.analyze(targetUri);
       return CallGraphPanel.current;
     }
 
@@ -28,14 +37,20 @@ export class CallGraphPanel {
       },
     );
 
-    CallGraphPanel.current = new CallGraphPanel(panel, context);
-    return CallGraphPanel.current;
+    const instance = new CallGraphPanel(panel, context, targetUri);
+    CallGraphPanel.current = instance;
+    return instance;
   }
+
+  private lastAnalyzedUri: vscode.Uri | undefined;
 
   private constructor(
     private readonly panel: vscode.WebviewPanel,
     private readonly context: vscode.ExtensionContext,
+    initialTargetUri: vscode.Uri | undefined,
   ) {
+    this.lastAnalyzedUri = initialTargetUri;
+
     this.panel.onDidDispose(() => {
       if (CallGraphPanel.current === this) {
         CallGraphPanel.current = undefined;
@@ -45,7 +60,9 @@ export class CallGraphPanel {
     this.panel.webview.onDidReceiveMessage(async (msg: WebviewToExtensionMessage) => {
       if (!msg || typeof msg !== 'object') return;
       if (msg.type === 'requestRefresh') {
-        await this.analyzeAndPost();
+        // Reuse the URI captured at command time; activeTextEditor is unreliable
+        // because the webview itself is focused when the user clicks Refresh.
+        await this.analyze(this.lastAnalyzedUri);
       } else if (msg.type === 'nodeClick') {
         // Navigation lands in #51; for now just ignore.
         return;
@@ -57,8 +74,26 @@ export class CallGraphPanel {
     });
   }
 
-  async analyzeActiveFile(): Promise<void> {
-    await this.analyzeAndPost();
+  /**
+   * Analyze a specific URI and post the result. If `uri` is provided, it
+   * replaces the panel's stored target so subsequent refreshes hit the same
+   * file. Pass `undefined` to fall back to the last captured target.
+   */
+  async analyze(uri: vscode.Uri | undefined): Promise<void> {
+    const target = uri ?? this.lastAnalyzedUri;
+    if (!target) {
+      this.post({
+        type: 'analysisError',
+        message: '분석할 파일이 없습니다. TypeScript 파일을 열고 Open Call Graph를 다시 실행하세요.',
+      });
+      return;
+    }
+
+    if (uri) {
+      this.lastAnalyzedUri = uri;
+    }
+
+    this.post(buildAnalysisMessage(target.fsPath));
   }
 
   private async bootstrap(): Promise<void> {
@@ -75,34 +110,7 @@ export class CallGraphPanel {
       return;
     }
 
-    await this.analyzeAndPost();
-  }
-
-  private async analyzeAndPost(): Promise<void> {
-    const editor = vscode.window.activeTextEditor;
-    if (!editor) {
-      this.post({ type: 'analysisError', message: '활성 에디터가 없습니다. .ts 파일을 열고 다시 시도하세요.' });
-      return;
-    }
-
-    const fsPath = editor.document.uri.fsPath;
-    if (!/\.(ts|tsx)$/.test(fsPath)) {
-      this.post({ type: 'analysisError', message: 'TypeScript 파일(.ts, .tsx)만 분석할 수 있습니다.' });
-      return;
-    }
-
-    let graph: CallGraph;
-    try {
-      graph = extractCallGraph(fsPath);
-    } catch (err) {
-      this.post({
-        type: 'analysisError',
-        message: `분석 중 오류: ${err instanceof Error ? err.message : String(err)}`,
-      });
-      return;
-    }
-
-    this.post({ type: 'analysisResult', graph });
+    await this.analyze(this.lastAnalyzedUri);
   }
 
   private post(message: ExtensionToWebviewMessage): void {

--- a/extension/src/callGraph/CallGraphPanel.ts
+++ b/extension/src/callGraph/CallGraphPanel.ts
@@ -43,6 +43,11 @@ export class CallGraphPanel {
   }
 
   private lastAnalyzedUri: vscode.Uri | undefined;
+  // Webview message listener mounts asynchronously after HTML loads. Delivering
+  // analysisResult before then would silently drop the first render. We hold
+  // the latest target URI and flush it once the webview signals webviewReady.
+  private webviewReady = false;
+  private pendingTargetUri: vscode.Uri | undefined;
 
   private constructor(
     private readonly panel: vscode.WebviewPanel,
@@ -50,6 +55,7 @@ export class CallGraphPanel {
     initialTargetUri: vscode.Uri | undefined,
   ) {
     this.lastAnalyzedUri = initialTargetUri;
+    this.pendingTargetUri = initialTargetUri;
 
     this.panel.onDidDispose(() => {
       if (CallGraphPanel.current === this) {
@@ -59,7 +65,12 @@ export class CallGraphPanel {
 
     this.panel.webview.onDidReceiveMessage(async (msg: WebviewToExtensionMessage) => {
       if (!msg || typeof msg !== 'object') return;
-      if (msg.type === 'requestRefresh') {
+      if (msg.type === 'webviewReady') {
+        this.webviewReady = true;
+        const target = this.pendingTargetUri;
+        this.pendingTargetUri = undefined;
+        await this.analyze(target);
+      } else if (msg.type === 'requestRefresh') {
         // Reuse the URI captured at command time; activeTextEditor is unreliable
         // because the webview itself is focused when the user clicks Refresh.
         await this.analyze(this.lastAnalyzedUri);
@@ -75,11 +86,22 @@ export class CallGraphPanel {
   }
 
   /**
-   * Analyze a specific URI and post the result. If `uri` is provided, it
-   * replaces the panel's stored target so subsequent refreshes hit the same
-   * file. Pass `undefined` to fall back to the last captured target.
+   * Analyze a specific URI and post the result. If the webview hasn't reported
+   * `webviewReady` yet, the target is queued and flushed once the listener is
+   * mounted; otherwise the message is posted immediately. `uri === undefined`
+   * means "reuse the last captured target" (e.g., Refresh from webview).
    */
   async analyze(uri: vscode.Uri | undefined): Promise<void> {
+    if (uri) {
+      this.lastAnalyzedUri = uri;
+    }
+
+    if (!this.webviewReady) {
+      // Defer until the webview reports it is ready.
+      this.pendingTargetUri = uri ?? this.pendingTargetUri ?? this.lastAnalyzedUri;
+      return;
+    }
+
     const target = uri ?? this.lastAnalyzedUri;
     if (!target) {
       this.post({
@@ -87,10 +109,6 @@ export class CallGraphPanel {
         message: '분석할 파일이 없습니다. TypeScript 파일을 열고 Open Call Graph를 다시 실행하세요.',
       });
       return;
-    }
-
-    if (uri) {
-      this.lastAnalyzedUri = uri;
     }
 
     this.post(buildAnalysisMessage(target.fsPath));
@@ -109,8 +127,9 @@ export class CallGraphPanel {
       );
       return;
     }
-
-    await this.analyze(this.lastAnalyzedUri);
+    // Do NOT post analysis here. The webview will send `webviewReady` once its
+    // message listener is attached, and the handler above flushes the queued
+    // target then.
   }
 
   private post(message: ExtensionToWebviewMessage): void {

--- a/extension/src/callGraph/buildAnalysisMessage.test.ts
+++ b/extension/src/callGraph/buildAnalysisMessage.test.ts
@@ -1,0 +1,46 @@
+import * as path from 'path';
+import { buildAnalysisMessage } from './buildAnalysisMessage';
+
+const fixturePath = path.join(__dirname, '..', 'analyzer', '__fixtures__', 'sample.ts');
+
+describe('buildAnalysisMessage', () => {
+  test('returns analysisResult with the extracted graph for a .ts file', () => {
+    const msg = buildAnalysisMessage(fixturePath);
+    expect(msg.type).toBe('analysisResult');
+    if (msg.type !== 'analysisResult') return;
+    // sample.ts has 5 function-like nodes (see analyzer fixture)
+    expect(msg.graph.nodes.map(n => n.name).sort()).toEqual([
+      'Service.run',
+      'Service.runInner',
+      'greet',
+      'helper',
+      'sayHi',
+    ]);
+  });
+
+  test('returns analysisError for non-TS files', () => {
+    const msg = buildAnalysisMessage('/tmp/whatever.js');
+    expect(msg).toEqual({
+      type: 'analysisError',
+      message: expect.stringContaining('TypeScript 파일'),
+    });
+  });
+
+  test('returns analysisError when the file cannot be read', () => {
+    const msg = buildAnalysisMessage('/nonexistent/path/file.ts');
+    expect(msg.type).toBe('analysisError');
+    if (msg.type !== 'analysisError') return;
+    expect(msg.message).toMatch(/분석 중 오류/);
+  });
+
+  test('accepts .tsx as well as .ts', () => {
+    // The extension allow-list should cover tsx; we exercise the regex branch
+    // with a missing file (which still passes the extension check, then errors).
+    const msg = buildAnalysisMessage('/nonexistent/path/file.tsx');
+    expect(msg.type).toBe('analysisError');
+    if (msg.type !== 'analysisError') return;
+    // Error must be the read error, NOT the "only .ts/.tsx" guard.
+    expect(msg.message).not.toContain('TypeScript 파일');
+    expect(msg.message).toMatch(/분석 중 오류/);
+  });
+});

--- a/extension/src/callGraph/buildAnalysisMessage.ts
+++ b/extension/src/callGraph/buildAnalysisMessage.ts
@@ -1,0 +1,24 @@
+import { extractCallGraph } from '../analyzer/callGraph';
+import type { CallGraph } from '../analyzer/types';
+import type { ExtensionToWebviewMessage } from './messages';
+
+/**
+ * Pure helper: given a filesystem path, produce the extension→webview message
+ * to post (analysisResult or analysisError). Kept free of `vscode.*` so jest
+ * can exercise it without spinning up an extension host.
+ */
+export function buildAnalysisMessage(fsPath: string): ExtensionToWebviewMessage {
+  if (!/\.(ts|tsx)$/.test(fsPath)) {
+    return { type: 'analysisError', message: 'TypeScript 파일(.ts, .tsx)만 분석할 수 있습니다.' };
+  }
+
+  try {
+    const graph: CallGraph = extractCallGraph(fsPath);
+    return { type: 'analysisResult', graph };
+  } catch (err) {
+    return {
+      type: 'analysisError',
+      message: `분석 중 오류: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/extension/src/callGraph/messages.ts
+++ b/extension/src/callGraph/messages.ts
@@ -14,6 +14,10 @@ export interface AnalysisErrorMessage {
 export type ExtensionToWebviewMessage = AnalysisResultMessage | AnalysisErrorMessage;
 
 // webview → extension
+export interface WebviewReadyMessage {
+  type: 'webviewReady';
+}
+
 export interface NodeClickMessage {
   type: 'nodeClick';
   nodeId: string;
@@ -23,4 +27,7 @@ export interface RequestRefreshMessage {
   type: 'requestRefresh';
 }
 
-export type WebviewToExtensionMessage = NodeClickMessage | RequestRefreshMessage;
+export type WebviewToExtensionMessage =
+  | WebviewReadyMessage
+  | NodeClickMessage
+  | RequestRefreshMessage;

--- a/extension/src/callGraph/messages.ts
+++ b/extension/src/callGraph/messages.ts
@@ -1,0 +1,26 @@
+import type { CallGraph } from '../analyzer/types';
+
+// extension → webview
+export interface AnalysisResultMessage {
+  type: 'analysisResult';
+  graph: CallGraph;
+}
+
+export interface AnalysisErrorMessage {
+  type: 'analysisError';
+  message: string;
+}
+
+export type ExtensionToWebviewMessage = AnalysisResultMessage | AnalysisErrorMessage;
+
+// webview → extension
+export interface NodeClickMessage {
+  type: 'nodeClick';
+  nodeId: string;
+}
+
+export interface RequestRefreshMessage {
+  type: 'requestRefresh';
+}
+
+export type WebviewToExtensionMessage = NodeClickMessage | RequestRefreshMessage;

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { CallGraphPanel } from './callGraph/CallGraphPanel';
 import { CanvasEditorProvider } from './CanvasEditorProvider';
 import { CodeAnalyzer } from './CodeAnalyzer';
 import { getStaleStatusesForPath, parseCanvasCodeCards } from './staleDetection';
@@ -12,6 +13,13 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(CanvasEditorProvider.register(context));
   context.subscriptions.push(registerStaleDetection());
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('codetrace.openCallGraph', async () => {
+      const panel = CallGraphPanel.createOrShow(context);
+      await panel.analyzeActiveFile();
+    }),
+  );
 
   context.subscriptions.push(
     vscode.commands.registerCommand('codetrace.analyzeRelationships', async () => {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -16,8 +16,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('codetrace.openCallGraph', async () => {
-      const panel = CallGraphPanel.createOrShow(context);
-      await panel.analyzeActiveFile();
+      // Capture the active editor's URI BEFORE creating/revealing the webview.
+      // Once the panel takes focus, vscode.window.activeTextEditor becomes
+      // undefined and we'd lose the analysis target.
+      const targetUri = vscode.window.activeTextEditor?.document.uri;
+      await CallGraphPanel.createOrShow(context, targetUri);
     }),
   );
 

--- a/extension/src/test/suite/buildAnalysisMessage.test.ts
+++ b/extension/src/test/suite/buildAnalysisMessage.test.ts
@@ -1,0 +1,44 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import { buildAnalysisMessage } from '../../callGraph/buildAnalysisMessage';
+
+const fixturePath = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'src',
+  'analyzer',
+  '__fixtures__',
+  'sample.ts',
+);
+
+suite('buildAnalysisMessage', () => {
+  test('returns analysisResult with the extracted graph for a .ts file', () => {
+    const msg = buildAnalysisMessage(fixturePath);
+    assert.strictEqual(msg.type, 'analysisResult');
+    if (msg.type !== 'analysisResult') return;
+    const names = msg.graph.nodes.map(n => n.name).sort();
+    assert.deepStrictEqual(names, [
+      'Service.run',
+      'Service.runInner',
+      'greet',
+      'helper',
+      'sayHi',
+    ]);
+  });
+
+  test('returns analysisError for non-TS files', () => {
+    const msg = buildAnalysisMessage('/tmp/whatever.js');
+    assert.strictEqual(msg.type, 'analysisError');
+    if (msg.type !== 'analysisError') return;
+    assert.ok(msg.message.includes('TypeScript 파일'));
+  });
+
+  test('returns analysisError when the file cannot be read', () => {
+    const msg = buildAnalysisMessage('/nonexistent/path/file.ts');
+    assert.strictEqual(msg.type, 'analysisError');
+    if (msg.type !== 'analysisError') return;
+    assert.ok(/분석 중 오류/.test(msg.message));
+  });
+});

--- a/frontend/callgraph.html
+++ b/frontend/callgraph.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>CodeTrace Call Graph</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body, #root { width: 100%; height: 100%; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/callGraphMain.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/CallGraphApp.css
+++ b/frontend/src/CallGraphApp.css
@@ -1,0 +1,53 @@
+.codetrace-callgraph-app {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  color: #1f2937;
+  background: #f9fafb;
+}
+
+.codetrace-callgraph-app__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #ffffff;
+}
+
+.codetrace-callgraph-app__title {
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.codetrace-callgraph-app__refresh {
+  font-size: 12px;
+  padding: 4px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.codetrace-callgraph-app__refresh:hover {
+  background: #f3f4f6;
+}
+
+.codetrace-callgraph-app__main {
+  flex: 1;
+  position: relative;
+}
+
+.codetrace-callgraph-app__placeholder,
+.codetrace-callgraph-app__error {
+  margin: 0;
+  padding: 24px;
+  text-align: center;
+  font-size: 13px;
+}
+
+.codetrace-callgraph-app__error {
+  color: #b91c1c;
+}

--- a/frontend/src/CallGraphApp.dom.test.tsx
+++ b/frontend/src/CallGraphApp.dom.test.tsx
@@ -1,0 +1,62 @@
+import { act, render, screen } from '@testing-library/react';
+import { CallGraphApp } from './CallGraphApp';
+import { SAMPLE_GRAPH } from './graph/__demo__/sampleGraph';
+import type { ExtensionToWebviewMessage } from './graph/messages';
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof ResizeObserverMock }).ResizeObserver =
+    ResizeObserverMock;
+
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({ width: 1200, height: 800, top: 0, left: 0, right: 1200, bottom: 800, x: 0, y: 0, toJSON: () => ({}) }),
+  });
+
+  if (typeof (globalThis as { DOMMatrixReadOnly?: unknown }).DOMMatrixReadOnly === 'undefined') {
+    (globalThis as { DOMMatrixReadOnly: unknown }).DOMMatrixReadOnly = class {
+      m22 = 1;
+      constructor() {}
+    };
+  }
+});
+
+function dispatchHostMessage(message: ExtensionToWebviewMessage) {
+  act(() => {
+    window.dispatchEvent(new MessageEvent('message', { data: message }));
+  });
+}
+
+describe('CallGraphApp', () => {
+  test('starts in idle state', () => {
+    render(<CallGraphApp />);
+    expect(screen.getByText(/분석을 기다리는 중/)).toBeInTheDocument();
+  });
+
+  test('renders the call graph after receiving analysisResult', () => {
+    const { container } = render(<CallGraphApp />);
+    dispatchHostMessage({ type: 'analysisResult', graph: SAMPLE_GRAPH });
+    const renderedNodes = container.querySelectorAll('.codetrace-fn-node');
+    expect(renderedNodes.length).toBe(SAMPLE_GRAPH.nodes.length);
+  });
+
+  test('shows analysisError message', () => {
+    render(<CallGraphApp />);
+    dispatchHostMessage({ type: 'analysisError', message: 'TS 파일이 아닙니다.' });
+    expect(screen.getByText('TS 파일이 아닙니다.')).toBeInTheDocument();
+  });
+
+  test('refresh button posts requestRefresh to host', () => {
+    const postMessage = jest.fn();
+    window.__codetrace_vscode = { postMessage };
+
+    render(<CallGraphApp />);
+    screen.getByRole('button', { name: /refresh/i }).click();
+
+    expect(postMessage).toHaveBeenCalledWith({ type: 'requestRefresh' });
+  });
+});

--- a/frontend/src/CallGraphApp.dom.test.tsx
+++ b/frontend/src/CallGraphApp.dom.test.tsx
@@ -32,6 +32,10 @@ function dispatchHostMessage(message: ExtensionToWebviewMessage) {
 }
 
 describe('CallGraphApp', () => {
+  beforeEach(() => {
+    window.__codetrace_vscode = undefined;
+  });
+
   test('starts in idle state', () => {
     render(<CallGraphApp />);
     expect(screen.getByText(/분석을 기다리는 중/)).toBeInTheDocument();
@@ -48,6 +52,18 @@ describe('CallGraphApp', () => {
     render(<CallGraphApp />);
     dispatchHostMessage({ type: 'analysisError', message: 'TS 파일이 아닙니다.' });
     expect(screen.getByText('TS 파일이 아닙니다.')).toBeInTheDocument();
+  });
+
+  test('posts webviewReady to host on mount, after the message listener attaches', () => {
+    const postMessage = jest.fn();
+    window.__codetrace_vscode = { postMessage };
+
+    render(<CallGraphApp />);
+
+    expect(postMessage).toHaveBeenCalledWith({ type: 'webviewReady' });
+    // The very first post must be webviewReady so the extension knows the
+    // listener is mounted before delivering analysisResult.
+    expect(postMessage.mock.calls[0][0]).toEqual({ type: 'webviewReady' });
   });
 
   test('refresh button posts requestRefresh to host', () => {

--- a/frontend/src/CallGraphApp.tsx
+++ b/frontend/src/CallGraphApp.tsx
@@ -30,6 +30,9 @@ export function CallGraphApp() {
       }
     };
     window.addEventListener('message', onMessage);
+    // Tell extension we're ready *after* the listener is attached. Posting
+    // earlier would race with extension's initial analysisResult delivery.
+    postToHost({ type: 'webviewReady' });
     return () => window.removeEventListener('message', onMessage);
   }, []);
 

--- a/frontend/src/CallGraphApp.tsx
+++ b/frontend/src/CallGraphApp.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { CallGraphCanvas } from './graph/CallGraphCanvas';
+import type {
+  ExtensionToWebviewMessage,
+  WebviewToExtensionMessage,
+} from './graph/messages';
+import type { CallGraph } from './graph/types';
+import './CallGraphApp.css';
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'loaded'; graph: CallGraph }
+  | { kind: 'error'; message: string };
+
+function postToHost(message: WebviewToExtensionMessage): void {
+  window.__codetrace_vscode?.postMessage(message);
+}
+
+export function CallGraphApp() {
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent<ExtensionToWebviewMessage>) => {
+      const msg = event.data;
+      if (!msg || typeof msg !== 'object') return;
+      if (msg.type === 'analysisResult') {
+        setStatus({ kind: 'loaded', graph: msg.graph });
+      } else if (msg.type === 'analysisError') {
+        setStatus({ kind: 'error', message: msg.message });
+      }
+    };
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, []);
+
+  return (
+    <div className="codetrace-callgraph-app">
+      <header className="codetrace-callgraph-app__bar">
+        <span className="codetrace-callgraph-app__title">Call Graph</span>
+        <button
+          type="button"
+          className="codetrace-callgraph-app__refresh"
+          onClick={() => postToHost({ type: 'requestRefresh' })}
+        >
+          Refresh
+        </button>
+      </header>
+      <main className="codetrace-callgraph-app__main">
+        {status.kind === 'idle' && (
+          <p className="codetrace-callgraph-app__placeholder">
+            분석을 기다리는 중입니다…
+          </p>
+        )}
+        {status.kind === 'error' && (
+          <p className="codetrace-callgraph-app__error">{status.message}</p>
+        )}
+        {status.kind === 'loaded' && <CallGraphCanvas graph={status.graph} />}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/callGraphMain.tsx
+++ b/frontend/src/callGraphMain.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { CallGraphApp } from './CallGraphApp';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <CallGraphApp />
+  </StrictMode>,
+);

--- a/frontend/src/graph/messages.ts
+++ b/frontend/src/graph/messages.ts
@@ -17,6 +17,10 @@ export interface AnalysisErrorMessage {
 export type ExtensionToWebviewMessage = AnalysisResultMessage | AnalysisErrorMessage;
 
 // webview → extension
+export interface WebviewReadyMessage {
+  type: 'webviewReady';
+}
+
 export interface NodeClickMessage {
   type: 'nodeClick';
   nodeId: string;
@@ -26,7 +30,10 @@ export interface RequestRefreshMessage {
   type: 'requestRefresh';
 }
 
-export type WebviewToExtensionMessage = NodeClickMessage | RequestRefreshMessage;
+export type WebviewToExtensionMessage =
+  | WebviewReadyMessage
+  | NodeClickMessage
+  | RequestRefreshMessage;
 
 export interface VsCodeApi {
   postMessage(message: WebviewToExtensionMessage): void;

--- a/frontend/src/graph/messages.ts
+++ b/frontend/src/graph/messages.ts
@@ -1,0 +1,39 @@
+// Mirrors extension/src/callGraph/messages.ts.
+// Both ends agree on this shape until a shared workspace package emerges.
+
+import type { CallGraph } from './types';
+
+// extension → webview
+export interface AnalysisResultMessage {
+  type: 'analysisResult';
+  graph: CallGraph;
+}
+
+export interface AnalysisErrorMessage {
+  type: 'analysisError';
+  message: string;
+}
+
+export type ExtensionToWebviewMessage = AnalysisResultMessage | AnalysisErrorMessage;
+
+// webview → extension
+export interface NodeClickMessage {
+  type: 'nodeClick';
+  nodeId: string;
+}
+
+export interface RequestRefreshMessage {
+  type: 'requestRefresh';
+}
+
+export type WebviewToExtensionMessage = NodeClickMessage | RequestRefreshMessage;
+
+export interface VsCodeApi {
+  postMessage(message: WebviewToExtensionMessage): void;
+}
+
+declare global {
+  interface Window {
+    __codetrace_vscode?: VsCodeApi;
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   plugins: [react()],
@@ -12,5 +13,13 @@ export default defineConfig({
   build: {
     outDir: '../extension/dist/webview',
     emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        // Existing Excalidraw canvas (used by .codetrace files).
+        index: resolve(__dirname, 'index.html'),
+        // Call-graph webview (used by codetrace.openCallGraph command).
+        callgraph: resolve(__dirname, 'callgraph.html'),
+      },
+    },
   },
 });


### PR DESCRIPTION
Resolves #50

## Summary
- 새 \`CallGraphPanel\` (WebviewPanel 싱글턴) + 새 명령 \`codetrace.openCallGraph\`
- 메시지 프로토콜 정의 (TypeScript discriminated union으로 컴파일 타임 검증):
  - extension → webview: \`analysisResult\`, \`analysisError\`
  - webview → extension: \`nodeClick\`, \`requestRefresh\`
- 새 frontend entry \`callgraph.html\` + \`CallGraphApp\` (idle/loaded/error 상태 분기 + Refresh 버튼)
- vite multi-entry로 기존 \`index\`(Excalidraw)와 새 \`callgraph\` 번들 공존

## 설계 결정
- **WebviewPanel vs CustomTextEditor:** 호출 그래프는 워크스페이스 단위라 파일 바인딩이 없는 WebviewPanel 채택
- **기존 코드 무수정:** \`CanvasEditorProvider\`/\`CodeAnalyzer\`/\`staleDetection\`/\`addSelectionToCanvas\` 등은 손대지 않음. cleanup은 #60에서 처리
- **명령 이름 충돌 회피:** 이슈 본문은 \`codetrace.analyzeWorkspace\`였으나 그 이름은 이미 기존 코드가 점유 (\`.codetrace/analysis_*.json\` 출력). 새 명령 \`codetrace.openCallGraph\`로 변경
- **노드 클릭 동작은 #51 범위:** 메시지 타입은 정의·전송 인프라까지 마련, 실제 점프는 #51

## 동작 흐름
1. 사용자: \`> CodeTrace: Open Call Graph\` 실행
2. extension: 활성 \`.ts\`/\`.tsx\` 파일 \`extractCallGraph\` → \`analysisResult\` post
3. webview: 메시지 수신 → \`CallGraphCanvas\` 렌더
4. 사용자: Refresh 버튼 → \`requestRefresh\` post → extension 재분석

## Out of scope
- 노드 클릭 → 에디터 점프 → #51
- 다중 파일 cross-file → #53
- 캐싱 → #57
- 기존 코드 정리 → #60

## Test plan
- [ ] \`cd frontend && npx jest\` → 52 통과 (CallGraphApp 4 신규)
- [ ] \`cd extension && npx jest src/analyzer\` → 8 통과 (회귀 없음)
- [ ] \`cd extension && npx tsc -p ./\` → 컴파일 에러 없음
- [ ] \`npm run build --workspace=frontend\` → \`dist/webview/index.html\`, \`dist/webview/callgraph.html\` 둘 다 생성
- [ ] EDH에서 \`Open Call Graph\` 실행 → 활성 .ts 파일 호출 그래프 렌더 확인