### PR TITLE
feat(analyzer): add cross-file call graph resolution

### DIFF
--- a/extension/src/analyzer/__fixtures__/cross-file/entry.ts
+++ b/extension/src/analyzer/__fixtures__/cross-file/entry.ts
@@ -1,0 +1,11 @@
+import { buildMessage } from './messages';
+import { Worker } from './worker';
+
+export function start(name: string): string {
+  const worker = new Worker();
+  return worker.run(buildMessage(name));
+}
+
+export const runAll = () => {
+  return start('Ada');
+};

--- a/extension/src/analyzer/__fixtures__/cross-file/messages.ts
+++ b/extension/src/analyzer/__fixtures__/cross-file/messages.ts
@@ -1,0 +1,7 @@
+export function buildMessage(name: string): string {
+  return normalize(name);
+}
+
+function normalize(name: string): string {
+  return name.trim();
+}

--- a/extension/src/analyzer/__fixtures__/cross-file/nested/local.ts
+++ b/extension/src/analyzer/__fixtures__/cross-file/nested/local.ts
@@ -1,0 +1,3 @@
+export function nestedEntry(): string {
+  return 'nested';
+}

--- a/extension/src/analyzer/__fixtures__/cross-file/tsconfig.json
+++ b/extension/src/analyzer/__fixtures__/cross-file/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "strict": true,
+    "moduleResolution": "node"
+  },
+  "include": ["*.ts"]
+}

--- a/extension/src/analyzer/__fixtures__/cross-file/worker.ts
+++ b/extension/src/analyzer/__fixtures__/cross-file/worker.ts
@@ -1,0 +1,9 @@
+export class Worker {
+  public run(message: string): string {
+    return this.decorate(message);
+  }
+
+  private decorate(value: string): string {
+    return `[${value}]`;
+  }
+}

--- a/extension/src/analyzer/callGraph.test.ts
+++ b/extension/src/analyzer/callGraph.test.ts
@@ -1,8 +1,18 @@
 import * as path from 'path';
-import { extractCallGraph, extractWorkspaceCallGraph } from './callGraph';
+import {
+  DEFAULT_ANALYZER_IGNORED_DIRECTORIES,
+  extractCallGraph,
+  extractCallGraphFromFiles,
+  extractWorkspaceCallGraph,
+} from './callGraph';
 
 const fixturePath = path.join(__dirname, '__fixtures__', 'sample.ts');
 const crossFileFixtureRoot = path.join(__dirname, '__fixtures__', 'cross-file');
+const crossFileFixtureFiles = [
+  path.join(crossFileFixtureRoot, 'entry.ts'),
+  path.join(crossFileFixtureRoot, 'messages.ts'),
+  path.join(crossFileFixtureRoot, 'worker.ts'),
+];
 
 describe('extractCallGraph (single file)', () => {
   const graph = extractCallGraph(fixturePath);
@@ -134,6 +144,35 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
         { from: start.id, to: buildMessage.id },
         { from: start.id, to: workerRun.id },
       ]),
+    );
+  });
+
+  test('does not implicitly climb to a parent tsconfig from a nested folder', () => {
+    const graph = extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'));
+
+    expect(graph.nodes.map(node => node.name)).toEqual(['nestedEntry']);
+  });
+
+  test('supports explicit file-list extraction for caller-owned discovery', () => {
+    const graph = extractCallGraphFromFiles(crossFileFixtureFiles);
+    const pairs = graph.edges.map(edge => {
+      const from = graph.nodes.find(node => node.id === edge.from)!;
+      const to = graph.nodes.find(node => node.id === edge.to)!;
+      return `${from.name}->${to.name}`;
+    }).sort();
+
+    expect(pairs).toEqual([
+      'Worker.run->Worker.decorate',
+      'buildMessage->normalize',
+      'runAll->start',
+      'start->Worker.run',
+      'start->buildMessage',
+    ]);
+  });
+
+  test('exposes the default fallback ignore policy', () => {
+    expect(DEFAULT_ANALYZER_IGNORED_DIRECTORIES).toEqual(
+      expect.arrayContaining(['.git', '.next', '.turbo', 'build', 'coverage', 'dist', 'node_modules', 'out']),
     );
   });
 });

--- a/extension/src/analyzer/callGraph.test.ts
+++ b/extension/src/analyzer/callGraph.test.ts
@@ -1,7 +1,8 @@
 import * as path from 'path';
-import { extractCallGraph } from './callGraph';
+import { extractCallGraph, extractWorkspaceCallGraph } from './callGraph';
 
 const fixturePath = path.join(__dirname, '__fixtures__', 'sample.ts');
+const crossFileFixtureRoot = path.join(__dirname, '__fixtures__', 'cross-file');
 
 describe('extractCallGraph (single file)', () => {
   const graph = extractCallGraph(fixturePath);
@@ -85,5 +86,54 @@ describe('extractCallGraph — unresolved receivers', () => {
     });
     expect(targets).not.toContain('Service.run');
     expect(targets).not.toContain('Worker.run');
+  });
+});
+
+describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
+  const graph = extractWorkspaceCallGraph(crossFileFixtureRoot);
+
+  test('loads all function-like nodes from the tsconfig workspace', () => {
+    const names = graph.nodes.map(n => n.name).sort();
+    expect(names).toEqual([
+      'Worker.decorate',
+      'Worker.run',
+      'buildMessage',
+      'normalize',
+      'runAll',
+      'start',
+    ]);
+  });
+
+  test('resolves imported functions and typed method calls across files', () => {
+    const pairs = graph.edges.map(edge => {
+      const from = graph.nodes.find(node => node.id === edge.from)!;
+      const to = graph.nodes.find(node => node.id === edge.to)!;
+      return `${from.name}->${to.name}`;
+    }).sort();
+
+    expect(pairs).toEqual([
+      'Worker.run->Worker.decorate',
+      'buildMessage->normalize',
+      'runAll->start',
+      'start->Worker.run',
+      'start->buildMessage',
+    ]);
+  });
+
+  test('records cross-file edge endpoints with their declaring files', () => {
+    const start = graph.nodes.find(node => node.name === 'start')!;
+    const buildMessage = graph.nodes.find(node => node.name === 'buildMessage')!;
+    const workerRun = graph.nodes.find(node => node.name === 'Worker.run')!;
+
+    expect(start.file).toContain(path.join('cross-file', 'entry.ts'));
+    expect(buildMessage.file).toContain(path.join('cross-file', 'messages.ts'));
+    expect(workerRun.file).toContain(path.join('cross-file', 'worker.ts'));
+
+    expect(graph.edges).toEqual(
+      expect.arrayContaining([
+        { from: start.id, to: buildMessage.id },
+        { from: start.id, to: workerRun.id },
+      ]),
+    );
   });
 });

--- a/extension/src/analyzer/callGraph.ts
+++ b/extension/src/analyzer/callGraph.ts
@@ -3,6 +3,28 @@ import * as path from 'path';
 import * as ts from 'typescript';
 import type { CallEdge, CallGraph, FunctionKind, FunctionNode, SourceRange } from './types';
 
+export const DEFAULT_ANALYZER_IGNORED_DIRECTORIES = [
+  '.git',
+  '.next',
+  '.turbo',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+] as const;
+
+export interface ExtractWorkspaceCallGraphOptions {
+  compilerOptions?: ts.CompilerOptions;
+  ignoredDirectories?: readonly string[];
+  searchParentTsconfig?: boolean;
+  tsconfigPath?: string;
+}
+
+/**
+ * Extracts a syntax-only graph for a single file. This preserves the original
+ * fast path, but cannot resolve imported symbols or typed receiver calls.
+ */
 export function extractCallGraph(filePath: string): CallGraph {
   const source = fs.readFileSync(filePath, 'utf8');
   const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
@@ -45,10 +67,17 @@ export function extractCallGraph(filePath: string): CallGraph {
   return { nodes, edges };
 }
 
-export function extractWorkspaceCallGraph(workspaceRoot: string): CallGraph {
+/**
+ * Extracts a typed graph for a workspace root using tsconfig.json when it is
+ * present directly in that root, then falls back to scanning TypeScript files.
+ */
+export function extractWorkspaceCallGraph(
+  workspaceRoot: string,
+  options: ExtractWorkspaceCallGraphOptions = {},
+): CallGraph {
   const root = path.resolve(workspaceRoot);
   const searchRoot = fs.statSync(root).isDirectory() ? root : path.dirname(root);
-  const configPath = ts.findConfigFile(searchRoot, ts.sys.fileExists, 'tsconfig.json');
+  const configPath = resolveTsConfigPath(searchRoot, options);
 
   if (configPath) {
     const config = ts.readConfigFile(configPath, ts.sys.readFile);
@@ -64,9 +93,16 @@ export function extractWorkspaceCallGraph(workspaceRoot: string): CallGraph {
     return extractProgramCallGraph(ts.createProgram(parsed.fileNames, parsed.options));
   }
 
-  return extractCallGraphFromFiles(findTypeScriptFiles(searchRoot));
+  return extractCallGraphFromFiles(
+    findTypeScriptFiles(searchRoot, options.ignoredDirectories),
+    options.compilerOptions,
+  );
 }
 
+/**
+ * Extracts a typed graph from an explicit file list. Useful for callers that
+ * already own workspace discovery and want Program/Checker resolution.
+ */
 export function extractCallGraphFromFiles(
   filePaths: readonly string[],
   compilerOptions: ts.CompilerOptions = {},
@@ -114,7 +150,6 @@ function extractProgramCallGraph(program: ts.Program): CallGraph {
         const symbol = getFunctionSymbol(declared.declNode, checker);
         if (symbol) {
           nodeIdBySymbol.set(resolveAliasedSymbol(symbol, checker), id);
-          nodeIdBySymbol.set(symbol, id);
         }
       }
 
@@ -297,15 +332,38 @@ function resolveAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Sy
   }
 }
 
-function findTypeScriptFiles(root: string): string[] {
+function resolveTsConfigPath(
+  searchRoot: string,
+  options: ExtractWorkspaceCallGraphOptions,
+): string | undefined {
+  if (options.tsconfigPath) {
+    return path.resolve(options.tsconfigPath);
+  }
+
+  const localConfigPath = path.join(searchRoot, 'tsconfig.json');
+  if (fs.existsSync(localConfigPath)) {
+    return localConfigPath;
+  }
+
+  if (options.searchParentTsconfig) {
+    return ts.findConfigFile(searchRoot, ts.sys.fileExists, 'tsconfig.json');
+  }
+
+  return undefined;
+}
+
+function findTypeScriptFiles(
+  root: string,
+  ignoredDirectories: readonly string[] = DEFAULT_ANALYZER_IGNORED_DIRECTORIES,
+): string[] {
   const files: string[] = [];
-  const ignoredDirectories = new Set(['.git', 'dist', 'node_modules', 'out']);
+  const ignoredDirectoryNames = new Set(ignoredDirectories);
 
   const visit = (directory: string) => {
     for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
       const fullPath = path.join(directory, entry.name);
       if (entry.isDirectory()) {
-        if (!ignoredDirectories.has(entry.name)) {
+        if (!ignoredDirectoryNames.has(entry.name)) {
           visit(fullPath);
         }
         continue;

--- a/extension/src/analyzer/callGraph.ts
+++ b/extension/src/analyzer/callGraph.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import * as ts from 'typescript';
 import type { CallEdge, CallGraph, FunctionKind, FunctionNode, SourceRange } from './types';
 
@@ -40,6 +41,108 @@ export function extractCallGraph(filePath: string): CallGraph {
     ts.forEachChild(node, visitCall);
   };
   ts.forEachChild(sourceFile, visitCall);
+
+  return { nodes, edges };
+}
+
+export function extractWorkspaceCallGraph(workspaceRoot: string): CallGraph {
+  const root = path.resolve(workspaceRoot);
+  const searchRoot = fs.statSync(root).isDirectory() ? root : path.dirname(root);
+  const configPath = ts.findConfigFile(searchRoot, ts.sys.fileExists, 'tsconfig.json');
+
+  if (configPath) {
+    const config = ts.readConfigFile(configPath, ts.sys.readFile);
+    if (config.error) {
+      throw new Error(formatDiagnostic(config.error));
+    }
+
+    const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, path.dirname(configPath));
+    if (parsed.errors.length > 0) {
+      throw new Error(parsed.errors.map(formatDiagnostic).join('\n'));
+    }
+
+    return extractProgramCallGraph(ts.createProgram(parsed.fileNames, parsed.options));
+  }
+
+  return extractCallGraphFromFiles(findTypeScriptFiles(searchRoot));
+}
+
+export function extractCallGraphFromFiles(
+  filePaths: readonly string[],
+  compilerOptions: ts.CompilerOptions = {},
+): CallGraph {
+  return extractProgramCallGraph(
+    ts.createProgram(
+      filePaths.map(filePath => path.resolve(filePath)),
+      {
+        target: ts.ScriptTarget.Latest,
+        module: ts.ModuleKind.CommonJS,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        skipLibCheck: true,
+        ...compilerOptions,
+      },
+    ),
+  );
+}
+
+function extractProgramCallGraph(program: ts.Program): CallGraph {
+  const checker = program.getTypeChecker();
+  const nodes: FunctionNode[] = [];
+  const nodeIdByDecl = new Map<ts.Node, string>();
+  const nodeIdBySymbol = new Map<ts.Symbol, string>();
+  const edges: CallEdge[] = [];
+  const edgeKeys = new Set<string>();
+  const sourceFiles = program.getSourceFiles().filter(sourceFile => {
+    return !sourceFile.isDeclarationFile && !program.isSourceFileFromExternalLibrary(sourceFile);
+  });
+
+  for (const sourceFile of sourceFiles) {
+    const collectScope = (parentName: string | undefined) => (node: ts.Node) => {
+      if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+        const className = node.name?.text ?? parentName ?? 'anonymous';
+        ts.forEachChild(node, collectScope(className));
+        return;
+      }
+
+      const declared = describeFunction(node, parentName);
+      if (declared) {
+        const file = path.normalize(sourceFile.fileName);
+        const id = makeId(file, declared.name, declared.range);
+        nodes.push({ id, name: declared.name, kind: declared.kind, file, range: declared.range });
+        nodeIdByDecl.set(declared.declNode, id);
+
+        const symbol = getFunctionSymbol(declared.declNode, checker);
+        if (symbol) {
+          nodeIdBySymbol.set(resolveAliasedSymbol(symbol, checker), id);
+          nodeIdBySymbol.set(symbol, id);
+        }
+      }
+
+      ts.forEachChild(node, collectScope(parentName));
+    };
+
+    ts.forEachChild(sourceFile, collectScope(undefined));
+  }
+
+  for (const sourceFile of sourceFiles) {
+    const visitCall = (node: ts.Node) => {
+      if (ts.isCallExpression(node)) {
+        const callerId = enclosingFunctionId(node, nodeIdByDecl);
+        const calleeId = resolveTypedCalleeId(node.expression, checker, nodeIdBySymbol);
+        if (callerId && calleeId) {
+          const key = `${callerId}->${calleeId}`;
+          if (!edgeKeys.has(key)) {
+            edgeKeys.add(key);
+            edges.push({ from: callerId, to: calleeId });
+          }
+        }
+      }
+
+      ts.forEachChild(node, visitCall);
+    };
+
+    ts.forEachChild(sourceFile, visitCall);
+  }
 
   return { nodes, edges };
 }
@@ -149,4 +252,79 @@ function resolveCallee(
   }
 
   return undefined;
+}
+
+function getFunctionSymbol(node: ts.Node, checker: ts.TypeChecker): ts.Symbol | undefined {
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return checker.getSymbolAtLocation(node.name);
+  }
+
+  if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
+    return checker.getSymbolAtLocation(node.name);
+  }
+
+  if (
+    (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+    ts.isVariableDeclaration(node.parent) &&
+    ts.isIdentifier(node.parent.name)
+  ) {
+    return checker.getSymbolAtLocation(node.parent.name);
+  }
+
+  return undefined;
+}
+
+function resolveTypedCalleeId(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  nodeIdBySymbol: Map<ts.Symbol, string>,
+): string | undefined {
+  const symbolNode = ts.isPropertyAccessExpression(expression) ? expression.name : expression;
+  const symbol = checker.getSymbolAtLocation(symbolNode);
+  if (!symbol) return undefined;
+
+  const resolved = resolveAliasedSymbol(symbol, checker);
+  return nodeIdBySymbol.get(resolved) ?? nodeIdBySymbol.get(symbol);
+}
+
+function resolveAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol {
+  if ((symbol.flags & ts.SymbolFlags.Alias) === 0) return symbol;
+
+  try {
+    return checker.getAliasedSymbol(symbol);
+  } catch {
+    return symbol;
+  }
+}
+
+function findTypeScriptFiles(root: string): string[] {
+  const files: string[] = [];
+  const ignoredDirectories = new Set(['.git', 'dist', 'node_modules', 'out']);
+
+  const visit = (directory: string) => {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!ignoredDirectories.has(entry.name)) {
+          visit(fullPath);
+        }
+        continue;
+      }
+
+      if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+        files.push(fullPath);
+      }
+    }
+  };
+
+  visit(root);
+  return files;
+}
+
+function formatDiagnostic(diagnostic: ts.Diagnostic): string {
+  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+  if (!diagnostic.file || diagnostic.start === undefined) return message;
+
+  const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+  return `${diagnostic.file.fileName}:${position.line + 1}:${position.character + 1} ${message}`;
 }

--- a/extension/src/test/suite/callGraph.test.ts
+++ b/extension/src/test/suite/callGraph.test.ts
@@ -1,6 +1,11 @@
 import * as assert from 'assert';
 import * as path from 'path';
-import { extractCallGraph, extractWorkspaceCallGraph } from '../../analyzer/callGraph';
+import {
+  DEFAULT_ANALYZER_IGNORED_DIRECTORIES,
+  extractCallGraph,
+  extractCallGraphFromFiles,
+  extractWorkspaceCallGraph,
+} from '../../analyzer/callGraph';
 
 // __dirname at runtime is `out/test/suite/`, but the fixture is a .ts source file
 // kept under `src/`. Resolve back to the workspace src tree.
@@ -24,6 +29,11 @@ const crossFileFixtureRoot = path.resolve(
   '__fixtures__',
   'cross-file',
 );
+const crossFileFixtureFiles = [
+  path.join(crossFileFixtureRoot, 'entry.ts'),
+  path.join(crossFileFixtureRoot, 'messages.ts'),
+  path.join(crossFileFixtureRoot, 'worker.ts'),
+];
 
 suite('extractCallGraph (single file)', () => {
   const graph = extractCallGraph(fixturePath);
@@ -160,5 +170,37 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
 
     assert.ok(graph.edges.some(edge => edge.from === start!.id && edge.to === buildMessage!.id));
     assert.ok(graph.edges.some(edge => edge.from === start!.id && edge.to === workerRun!.id));
+  });
+
+  test('does not implicitly climb to a parent tsconfig from a nested folder', () => {
+    const graph = extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'));
+
+    assert.deepStrictEqual(graph.nodes.map(node => node.name), ['nestedEntry']);
+  });
+
+  test('supports explicit file-list extraction for caller-owned discovery', () => {
+    const graph = extractCallGraphFromFiles(crossFileFixtureFiles);
+    const pairs = graph.edges
+      .map(edge => {
+        const from = graph.nodes.find(node => node.id === edge.from);
+        const to = graph.nodes.find(node => node.id === edge.to);
+        return `${from?.name}->${to?.name}`;
+      })
+      .sort();
+
+    assert.deepStrictEqual(pairs, [
+      'Worker.run->Worker.decorate',
+      'buildMessage->normalize',
+      'runAll->start',
+      'start->Worker.run',
+      'start->buildMessage',
+    ]);
+  });
+
+  test('exposes the default fallback ignore policy', () => {
+    const ignoredDirectories: readonly string[] = DEFAULT_ANALYZER_IGNORED_DIRECTORIES;
+    for (const directory of ['.git', '.next', '.turbo', 'build', 'coverage', 'dist', 'node_modules', 'out']) {
+      assert.ok(ignoredDirectories.includes(directory));
+    }
   });
 });

--- a/extension/src/test/suite/callGraph.test.ts
+++ b/extension/src/test/suite/callGraph.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'assert';
 import * as path from 'path';
-import { extractCallGraph } from '../../analyzer/callGraph';
+import { extractCallGraph, extractWorkspaceCallGraph } from '../../analyzer/callGraph';
 
 // __dirname at runtime is `out/test/suite/`, but the fixture is a .ts source file
 // kept under `src/`. Resolve back to the workspace src tree.
@@ -13,6 +13,16 @@ const fixturePath = path.resolve(
   'analyzer',
   '__fixtures__',
   'sample.ts',
+);
+const crossFileFixtureRoot = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'src',
+  'analyzer',
+  '__fixtures__',
+  'cross-file',
 );
 
 suite('extractCallGraph (single file)', () => {
@@ -100,5 +110,55 @@ suite('extractCallGraph — unresolved receivers', () => {
     const targets = graph.edges.map(e => graph.nodes.find(n => n.id === e.to)?.name);
     assert.ok(!targets.includes('Service.run'));
     assert.ok(!targets.includes('Worker.run'));
+  });
+});
+
+suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
+  const graph = extractWorkspaceCallGraph(crossFileFixtureRoot);
+
+  test('loads all function-like nodes from the tsconfig workspace', () => {
+    const names = graph.nodes.map(n => n.name).sort();
+    assert.deepStrictEqual(names, [
+      'Worker.decorate',
+      'Worker.run',
+      'buildMessage',
+      'normalize',
+      'runAll',
+      'start',
+    ]);
+  });
+
+  test('resolves imported functions and typed method calls across files', () => {
+    const pairs = graph.edges
+      .map(edge => {
+        const from = graph.nodes.find(node => node.id === edge.from);
+        const to = graph.nodes.find(node => node.id === edge.to);
+        return `${from?.name}->${to?.name}`;
+      })
+      .sort();
+
+    assert.deepStrictEqual(pairs, [
+      'Worker.run->Worker.decorate',
+      'buildMessage->normalize',
+      'runAll->start',
+      'start->Worker.run',
+      'start->buildMessage',
+    ]);
+  });
+
+  test('records cross-file edge endpoints with their declaring files', () => {
+    const start = graph.nodes.find(node => node.name === 'start');
+    const buildMessage = graph.nodes.find(node => node.name === 'buildMessage');
+    const workerRun = graph.nodes.find(node => node.name === 'Worker.run');
+    assert.ok(start, 'start node missing');
+    assert.ok(buildMessage, 'buildMessage node missing');
+    assert.ok(workerRun, 'Worker.run node missing');
+
+    assert.ok(start!.file.includes(path.join('cross-file', 'entry.ts')));
+    assert.ok(buildMessage!.file.includes(path.join('cross-file', 'messages.ts')));
+    assert.ok(workerRun!.file.includes(path.join('cross-file', 'worker.ts')));
+
+    assert.ok(graph.edges.some(edge => edge.from === start!.id && edge.to === buildMessage!.id));
+    assert.ok(graph.edges.some(edge => edge.from === start!.id && edge.to === workerRun!.id));
   });
 });


### PR DESCRIPTION
## Summary
- Add Program/TypeChecker-based workspace call graph extraction with tsconfig auto-detection.
- Resolve imported function calls and typed method calls across TypeScript files.
- Add a three-file cross-file fixture and coverage in both analyzer Jest tests and VS Code extension suite tests.

## Validation
- npm test --workspace=extension
- npm exec --workspace=extension -- jest src/analyzer/callGraph.test.ts --config jest.config.cjs --runInBand
- npm run build
- git diff --check

Closes #53