### PR TITLE
docs(analyzer): propose cross-file analyzer direction

### DIFF
--- a/.codetrace/canvases/canvas.codetrace
+++ b/.codetrace/canvases/canvas.codetrace
@@ -1,8 +1,0 @@
-{
-  "version": 1,
-  "elements": [],
-  "cards": [],
-  "appState": {
-    "collaborators": {}
-  }
-}

--- a/.codetrace/canvases/canvas.codetrace
+++ b/.codetrace/canvases/canvas.codetrace
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "elements": [],
+  "cards": [],
+  "appState": {
+    "collaborators": {}
+  }
+}

--- a/extension/src/analyzer/GenericLspAnalyzer.ts
+++ b/extension/src/analyzer/GenericLspAnalyzer.ts
@@ -1,0 +1,132 @@
+import * as vscode from 'vscode';
+import type { Analyzer, CallGraph, FunctionNode, PrecisionTier } from './types';
+
+export class GenericLspAnalyzer implements Analyzer {
+  getName(): string {
+    return 'VS Code LSP Adapter';
+  }
+
+  getPrecision(): PrecisionTier {
+    return 'standard';
+  }
+
+  canAnalyze(filePaths: string[]): boolean {
+    // LSP adapter can theoretically try to analyze anything VS Code supports.
+    return filePaths.length > 0;
+  }
+
+  async analyze(workspaceRoot: string, filePaths: string[], options: any = {}): Promise<CallGraph> {
+    const nodes: FunctionNode[] = [];
+    const edges: { from: string; to: string }[] = [];
+    const nodeIdByLocation = new Map<string, string>();
+
+    for (const filePath of filePaths) {
+      const uri = vscode.Uri.file(filePath);
+      try {
+        const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+          'vscode.executeDocumentSymbolProvider',
+          uri
+        );
+
+        if (symbols) {
+          const flatSymbols = this._flattenSymbols(symbols, uri);
+          for (const symbol of flatSymbols) {
+            const isCallable = symbol.kind === vscode.SymbolKind.Function || 
+                               symbol.kind === vscode.SymbolKind.Method || 
+                               symbol.kind === vscode.SymbolKind.Constructor;
+
+            if (isCallable) {
+              const id = `${uri.fsPath}#${symbol.name}@${symbol.range.start.line + 1}:${symbol.range.start.character + 1}`;
+              nodes.push({
+                id,
+                name: symbol.name,
+                kind: this._mapKind(symbol.kind),
+                file: uri.fsPath,
+                range: {
+                  startLine: symbol.range.start.line + 1,
+                  startColumn: symbol.range.start.character + 1,
+                  endLine: symbol.range.end.line + 1,
+                  endColumn: symbol.range.end.character + 1
+                }
+              });
+              nodeIdByLocation.set(`${uri.toString()}#${symbol.range.start.line}:${symbol.range.start.character}`, id);
+            }
+          }
+        }
+      } catch (err) {
+        console.error(`Failed to analyze ${filePath}: ${err}`);
+      }
+    }
+
+    // Second pass for edges
+    for (const node of nodes) {
+      try {
+        const uri = vscode.Uri.file(node.file);
+        const pos = new vscode.Position(node.range.startLine - 1, node.range.startColumn - 1);
+        
+        const callItems = await vscode.commands.executeCommand<vscode.CallHierarchyItem[]>(
+          'vscode.prepareCallHierarchy',
+          uri,
+          pos
+        );
+
+        if (callItems && callItems.length > 0) {
+          const outgoing = await vscode.commands.executeCommand<vscode.CallHierarchyOutgoingCall[]>(
+            'vscode.provideOutgoingCalls',
+            callItems[0]
+          );
+
+          if (outgoing) {
+            for (const call of outgoing) {
+              const toId = `${call.to.uri.fsPath}#${call.to.name}@${call.to.selectionRange.start.line + 1}:${call.to.selectionRange.start.character + 1}`;
+              edges.push({ from: node.id, to: toId });
+              
+              // If we haven't seen this target node yet, add a stub for it
+              if (!nodes.find(n => n.id === toId)) {
+                nodes.push({
+                  id: toId,
+                  name: call.to.name,
+                  kind: this._mapKind(call.to.kind),
+                  file: call.to.uri.fsPath,
+                  range: {
+                    startLine: call.to.selectionRange.start.line + 1,
+                    startColumn: call.to.selectionRange.start.character + 1,
+                    endLine: call.to.selectionRange.end.line + 1,
+                    endColumn: call.to.selectionRange.end.character + 1
+                  }
+                });
+              }
+            }
+          }
+        }
+      } catch (err) {
+        // Some symbols might not support call hierarchy
+      }
+    }
+
+    return {
+      nodes,
+      edges,
+      metadata: {
+        engine: this.getName(),
+        language: 'Generic (LSP)',
+        precision: this.getPrecision(),
+      }
+    };
+  }
+
+  private _flattenSymbols(symbols: vscode.DocumentSymbol[], uri: vscode.Uri): vscode.DocumentSymbol[] {
+    const flat: vscode.DocumentSymbol[] = [];
+    const traverse = (s: vscode.DocumentSymbol) => {
+      flat.push(s);
+      s.children?.forEach(traverse);
+    };
+    symbols.forEach(traverse);
+    return flat;
+  }
+
+  private _mapKind(kind: vscode.SymbolKind): 'function' | 'method' | 'arrow' {
+    if (kind === vscode.SymbolKind.Method) return 'method';
+    return 'function'; // Default for LSP
+  }
+}

--- a/extension/src/analyzer/GenericLspAnalyzer.ts
+++ b/extension/src/analyzer/GenericLspAnalyzer.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import type { Analyzer, CallGraph, FunctionNode, PrecisionTier } from './types';
+import type { Analyzer, AnalyzerOptions, CallGraph, FunctionNode, PrecisionTier } from './types';
 
 export class GenericLspAnalyzer implements Analyzer {
   getName(): string {
@@ -11,14 +11,13 @@ export class GenericLspAnalyzer implements Analyzer {
   }
 
   canAnalyze(filePaths: string[]): boolean {
-    // LSP adapter can theoretically try to analyze anything VS Code supports.
     return filePaths.length > 0;
   }
 
-  async analyze(workspaceRoot: string, filePaths: string[], options: any = {}): Promise<CallGraph> {
+  async analyze(workspaceRoot: string, filePaths: string[], options: AnalyzerOptions = {}): Promise<CallGraph> {
     const nodes: FunctionNode[] = [];
     const edges: { from: string; to: string }[] = [];
-    const nodeIdByLocation = new Map<string, string>();
+    const nodeMap = new Map<string, FunctionNode>();
 
     for (const filePath of filePaths) {
       const uri = vscode.Uri.file(filePath);
@@ -37,7 +36,7 @@ export class GenericLspAnalyzer implements Analyzer {
 
             if (isCallable) {
               const id = `${uri.fsPath}#${symbol.name}@${symbol.range.start.line + 1}:${symbol.range.start.character + 1}`;
-              nodes.push({
+              const node: FunctionNode = {
                 id,
                 name: symbol.name,
                 kind: this._mapKind(symbol.kind),
@@ -48,8 +47,9 @@ export class GenericLspAnalyzer implements Analyzer {
                   endLine: symbol.range.end.line + 1,
                   endColumn: symbol.range.end.character + 1
                 }
-              });
-              nodeIdByLocation.set(`${uri.toString()}#${symbol.range.start.line}:${symbol.range.start.character}`, id);
+              };
+              nodes.push(node);
+              nodeMap.set(id, node);
             }
           }
         }
@@ -81,9 +81,8 @@ export class GenericLspAnalyzer implements Analyzer {
               const toId = `${call.to.uri.fsPath}#${call.to.name}@${call.to.selectionRange.start.line + 1}:${call.to.selectionRange.start.character + 1}`;
               edges.push({ from: node.id, to: toId });
               
-              // If we haven't seen this target node yet, add a stub for it
-              if (!nodes.find(n => n.id === toId)) {
-                nodes.push({
+              if (!nodeMap.has(toId)) {
+                const newNode: FunctionNode = {
                   id: toId,
                   name: call.to.name,
                   kind: this._mapKind(call.to.kind),
@@ -94,7 +93,9 @@ export class GenericLspAnalyzer implements Analyzer {
                     endLine: call.to.selectionRange.end.line + 1,
                     endColumn: call.to.selectionRange.end.character + 1
                   }
-                });
+                };
+                nodes.push(newNode);
+                nodeMap.set(toId, newNode);
               }
             }
           }

--- a/extension/src/analyzer/GenericLspAnalyzer.ts
+++ b/extension/src/analyzer/GenericLspAnalyzer.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as vscode from 'vscode';
 import type { Analyzer, AnalyzerOptions, CallGraph, FunctionNode, PrecisionTier } from './types';
 
@@ -18,8 +19,17 @@ export class GenericLspAnalyzer implements Analyzer {
     const nodes: FunctionNode[] = [];
     const edges: { from: string; to: string }[] = [];
     const nodeMap = new Map<string, FunctionNode>();
+    
+    const limitPaths = options.limitToFiles 
+      ? new Set(options.limitToFiles.map(p => path.normalize(path.resolve(p))))
+      : undefined;
 
     for (const filePath of filePaths) {
+      const normalizedPath = path.normalize(path.resolve(filePath));
+      const canBePrimaryNode = limitPaths ? limitPaths.has(normalizedPath) : true;
+      
+      if (!canBePrimaryNode) continue;
+
       const uri = vscode.Uri.file(filePath);
       try {
         const symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
@@ -58,7 +68,7 @@ export class GenericLspAnalyzer implements Analyzer {
       }
     }
 
-    // Second pass for edges
+    // Second pass for edges - only FROM nodes that were collected
     for (const node of nodes) {
       try {
         const uri = vscode.Uri.file(node.file);

--- a/extension/src/analyzer/PROPOSAL_ISSUE_52.md
+++ b/extension/src/analyzer/PROPOSAL_ISSUE_52.md
@@ -1,22 +1,35 @@
-# Proposal: Cross-File Function Call Analyzer (Issue #52)
+# Proposal: Multi-Language Hybrid Analyzer Architecture (Relates to #52)
 
 ## 1. 개요
-이슈 #52의 목적은 현재 단일 파일에 국한된 함수 호출 분석을 프로젝트 단위(Cross-file)로 확장하는 것입니다.
+본 제안서는 이슈 #52 및 #53의 구현 성과(TypeScript Compiler API 도입)를 바탕으로, CodeTrace가 지향해야 할 **'고정밀 분석'과 '범용성'**을 동시에 충족하기 위한 하이브리드 분석기 아키텍처를 정의합니다.
 
-## 2. 제안하는 방식: TypeScript Compiler API 활용
-- `ts.createProgram`을 사용하여 프로젝트 전체의 세만틱 모델을 구축.
-- `ts.TypeChecker`를 활용해 `import/export`를 추적하고 정확한 심볼 선언부를 식별.
+## 2. 분석 정밀도 계층 (Precision Tiers)
+CodeTrace는 사용자에게 혼란을 줄 수 있는 저정밀 분석(단순 AST)을 지양하고, 신뢰할 수 있는 수준의 두 가지 정밀도 계층을 운영합니다.
 
-## 3. 예상되는 한계점 (논의 필요)
-- **언어 제한**: 이 방식은 TypeScript 및 JavaScript 전용입니다.
-- **타 언어 지원**: Python, Go, Java 등 다른 언어는 이 엔진으로 분석할 수 없으며, 추후 Tree-sitter나 LSP(Language Server Protocol) 기반의 별도 엔진이 필요합니다.
-- **성능**: 대규모 프로젝트에서 `createProgram` 시 발생하는 메모리 사용량 및 초기 로딩 시간 검증이 필요합니다.
+- **Standard Tier (LSP-based)**: VS Code의 Language Server Protocol 정보를 활용합니다. 여러 언어를 지원하는 범용적인 방식이며, `CodeAnalyzer.ts`의 로직을 어댑터화하여 재활용합니다. (에디터 의존적이지만 폭넓은 언어 지원)
+- **Premium Tier (Compiler API-based)**: 언어별 특화 엔진(예: TS Compiler API)을 사용하여 타입 및 심볼 참조를 완벽하게 추적합니다. (현재 TS/JS 전용 구현 완료, 에디터 독립적 분석 가능)
 
-## 4. 논의하고 싶은 점
-- 우선 TS/JS 생태계에 집중하여 고정밀 분석 엔진을 구축하는 방향이 우리 프로젝트의 우선순위와 맞을까요?
-- 타 언어 지원을 위해 범용적이지만 정밀도가 낮은 LSP 방식을 병행할지, 아니면 언어별 특화 엔진을 순차적으로 늘려갈지 의견을 듣고 싶습니다.
+## 3. 하이브리드 아키텍처 (Hybrid Architecture)
+겉은 하나의 표준 인터페이스로 통합하되, 상황에 따라 최적의 엔진을 선택하는 **전략 패턴(Strategy Pattern)**을 도입합니다.
 
-## 5. 향후 계획
-- [ ] `extractCallGraph` 함수 리팩토링 (Program/TypeChecker 도입)
-- [ ] 파일 간 호출 관계 검증을 위한 테스트 피스처 추가
-- [ ] 대규모 워크스페이스 성능 테스트
+### 3.1 공통 인터페이스 (`Analyzer` Interface)
+모든 분석 엔진은 내부 구현에 상관없이 동일한 데이터 구조를 반환합니다.
+```ts
+interface Analyzer {
+  // 프로젝트 루트를 받아 분석된 호출 그래프를 반환
+  analyze(workspaceRoot: string): Promise<CallGraph>;
+}
+```
+
+### 3.2 엔진 구성 및 역할 분담
+- **`TypeScriptAnalyzer` (Premium)**: TS/JS 프로젝트에서 동작하며, `ts.createProgram`을 통해 가장 정밀한 결과를 제공합니다.
+- **`GenericLspAnalyzer` (Standard)**: 그 외 모든 언어에서 동작하며, 기존 `CodeAnalyzer.ts`의 LSP 통신 로직을 통해 기본적인 관계를 찾아냅니다.
+
+## 4. 논의 및 향후 계획
+- [x] **Premium 엔진(TS/JS) 구현** (PR #64 완료)
+- [x] **아키텍처 리팩토링**: 현재 TS에 결합된 로직을 위 `Analyzer` 인터페이스 기반으로 분리.
+- [x] **Standard 어댑터 개발**: `CodeAnalyzer.ts` 로직을 독립적인 `Analyzer` 구현체로 이식.
+- [x] **엔진 자동 선택**: 언어 환경에 따라 `Premium` 지원 시 우선 사용, 미지원 시 `Standard`로 폴백(Fallback).
+
+---
+불완전한 분석(Level 1)을 배제하고 **'검증된 데이터'**만을 제공함으로써, CodeTrace는 사용자에게 더욱 신뢰받는 시각화 도구가 될 것입니다.

--- a/extension/src/analyzer/PROPOSAL_ISSUE_52.md
+++ b/extension/src/analyzer/PROPOSAL_ISSUE_52.md
@@ -1,0 +1,22 @@
+# Proposal: Cross-File Function Call Analyzer (Issue #52)
+
+## 1. 개요
+이슈 #52의 목적은 현재 단일 파일에 국한된 함수 호출 분석을 프로젝트 단위(Cross-file)로 확장하는 것입니다.
+
+## 2. 제안하는 방식: TypeScript Compiler API 활용
+- `ts.createProgram`을 사용하여 프로젝트 전체의 세만틱 모델을 구축.
+- `ts.TypeChecker`를 활용해 `import/export`를 추적하고 정확한 심볼 선언부를 식별.
+
+## 3. 예상되는 한계점 (논의 필요)
+- **언어 제한**: 이 방식은 TypeScript 및 JavaScript 전용입니다.
+- **타 언어 지원**: Python, Go, Java 등 다른 언어는 이 엔진으로 분석할 수 없으며, 추후 Tree-sitter나 LSP(Language Server Protocol) 기반의 별도 엔진이 필요합니다.
+- **성능**: 대규모 프로젝트에서 `createProgram` 시 발생하는 메모리 사용량 및 초기 로딩 시간 검증이 필요합니다.
+
+## 4. 논의하고 싶은 점
+- 우선 TS/JS 생태계에 집중하여 고정밀 분석 엔진을 구축하는 방향이 우리 프로젝트의 우선순위와 맞을까요?
+- 타 언어 지원을 위해 범용적이지만 정밀도가 낮은 LSP 방식을 병행할지, 아니면 언어별 특화 엔진을 순차적으로 늘려갈지 의견을 듣고 싶습니다.
+
+## 5. 향후 계획
+- [ ] `extractCallGraph` 함수 리팩토링 (Program/TypeChecker 도입)
+- [ ] 파일 간 호출 관계 검증을 위한 테스트 피스처 추가
+- [ ] 대규모 워크스페이스 성능 테스트

--- a/extension/src/analyzer/TypeScriptAnalyzer.ts
+++ b/extension/src/analyzer/TypeScriptAnalyzer.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 import type { Analyzer, AnalyzerOptions, CallEdge, CallGraph, FunctionNode, PrecisionTier } from './types';
-import { describeFunction, enclosingFunctionId, makeId } from './utils';
+import { describeFunction, enclosingFunctionId, getOwnerName, makeId } from './utils';
 
 export class TypeScriptAnalyzer implements Analyzer {
   getName(): string {
@@ -50,6 +50,9 @@ export class TypeScriptAnalyzer implements Analyzer {
     const edgeKeys = new Set<string>();
     
     const requestedPaths = new Set(filePaths.map(p => path.normalize(path.resolve(p))));
+    const limitPaths = options.limitToFiles 
+      ? new Set(options.limitToFiles.map(p => path.normalize(path.resolve(p))))
+      : undefined;
 
     const allSourceFiles = program.getSourceFiles().filter(sourceFile => {
       return !sourceFile.isDeclarationFile && !program.isSourceFileFromExternalLibrary(sourceFile);
@@ -58,7 +61,9 @@ export class TypeScriptAnalyzer implements Analyzer {
     // First pass: Collect nodes from requested files
     for (const sourceFile of allSourceFiles) {
       const normalizedSourcePath = path.normalize(sourceFile.fileName);
-      const isRequested = requestedPaths.has(normalizedSourcePath);
+      const canBePrimaryNode = limitPaths 
+        ? limitPaths.has(normalizedSourcePath)
+        : requestedPaths.has(normalizedSourcePath);
 
       const collectScope = (parentName: string | undefined) => (node: ts.Node) => {
         if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
@@ -72,7 +77,7 @@ export class TypeScriptAnalyzer implements Analyzer {
           const file = normalizedSourcePath;
           const id = makeId(file, declared.name, declared.range);
           
-          if (isRequested) {
+          if (canBePrimaryNode) {
             nodes.push({ id, name: declared.name, kind: declared.kind, file, range: declared.range });
             nodeIdByDecl.set(declared.declNode, id);
           }
@@ -93,7 +98,12 @@ export class TypeScriptAnalyzer implements Analyzer {
     const nodeIds = new Set(nodes.map(n => n.id));
     
     for (const sourceFile of allSourceFiles) {
-      if (!requestedPaths.has(path.normalize(sourceFile.fileName))) continue;
+      const normalizedSourcePath = path.normalize(sourceFile.fileName);
+      const canBeSource = limitPaths 
+        ? limitPaths.has(normalizedSourcePath)
+        : requestedPaths.has(normalizedSourcePath);
+
+      if (!canBeSource) continue;
 
       const visitCall = (node: ts.Node) => {
         if (ts.isCallExpression(node)) {
@@ -114,7 +124,8 @@ export class TypeScriptAnalyzer implements Analyzer {
                   
                   if (decl) {
                     const calleeFile = path.normalize(decl.getSourceFile().fileName);
-                    const desc = describeFunction(decl, undefined);
+                    const ownerName = getOwnerName(decl);
+                    const desc = describeFunction(decl, ownerName);
                     if (desc) {
                       nodes.push({
                         id: calleeId,
@@ -128,17 +139,10 @@ export class TypeScriptAnalyzer implements Analyzer {
                   }
                 }
               }
-            } else {
-              // Optionally track unresolved calls for UI hints
-              const unresolvedTarget = ts.isPropertyAccessExpression(node.expression) 
-                ? node.expression.name.text 
-                : node.expression.getText();
-              
-              if (!edgeKeys.has(key)) {
-                edgeKeys.add(key);
-                // We don't have a to-ID, but we can signal it's unresolved
-                // In v2, we might want a special to-ID for unresolved targets
-              }
+            } else if (!edgeKeys.has(key)) {
+              edgeKeys.add(key);
+              // In v2.1, we signal unresolved calls
+              edges.push({ from: callerId, to: 'unresolved', unresolved: true });
             }
           }
         }

--- a/extension/src/analyzer/TypeScriptAnalyzer.ts
+++ b/extension/src/analyzer/TypeScriptAnalyzer.ts
@@ -1,0 +1,207 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+import type { Analyzer, CallEdge, CallGraph, FunctionNode, PrecisionTier } from './types';
+import { describeFunction, enclosingFunctionId, makeId } from './utils';
+
+export class TypeScriptAnalyzer implements Analyzer {
+  getName(): string {
+    return 'TypeScript Compiler API';
+  }
+
+  getPrecision(): PrecisionTier {
+    return 'premium';
+  }
+
+  canAnalyze(filePaths: string[]): boolean {
+    return filePaths.some(f => f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.js') || f.endsWith('.jsx'));
+  }
+
+  async analyze(workspaceRoot: string, filePaths: string[], options: any = {}): Promise<CallGraph> {
+    const root = path.resolve(workspaceRoot);
+    const configPath = this.resolveTsConfigPath(root, options);
+    
+    let program: ts.Program;
+    if (configPath) {
+      const config = ts.readConfigFile(configPath, ts.sys.readFile);
+      const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, path.dirname(configPath));
+      program = ts.createProgram(parsed.fileNames, parsed.options);
+    } else {
+      program = ts.createProgram(
+        filePaths.map(filePath => path.resolve(filePath)),
+        {
+          target: ts.ScriptTarget.Latest,
+          module: ts.ModuleKind.CommonJS,
+          moduleResolution: ts.ModuleResolutionKind.NodeJs,
+          skipLibCheck: true,
+        },
+      );
+    }
+
+    const checker = program.getTypeChecker();
+    const nodes: FunctionNode[] = [];
+    const nodeIdByDecl = new Map<ts.Node, string>();
+    const nodeIdBySymbol = new Map<ts.Symbol, string>();
+    const edges: CallEdge[] = [];
+    const edgeKeys = new Set<string>();
+    
+    const requestedPaths = new Set(filePaths.map(p => path.normalize(path.resolve(p))));
+
+    const allSourceFiles = program.getSourceFiles().filter(sourceFile => {
+      return !sourceFile.isDeclarationFile && !program.isSourceFileFromExternalLibrary(sourceFile);
+    });
+
+    // First pass: Collect nodes only for requested files
+    for (const sourceFile of allSourceFiles) {
+      const normalizedSourcePath = path.normalize(sourceFile.fileName);
+      const isRequested = requestedPaths.has(normalizedSourcePath);
+
+      const collectScope = (parentName: string | undefined) => (node: ts.Node) => {
+        if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
+          const className = node.name?.text ?? parentName ?? 'anonymous';
+          ts.forEachChild(node, collectScope(className));
+          return;
+        }
+
+        const declared = describeFunction(node, parentName);
+        if (declared) {
+          const file = normalizedSourcePath;
+          const id = makeId(file, declared.name, declared.range);
+          
+          if (isRequested) {
+            nodes.push({ id, name: declared.name, kind: declared.kind, file, range: declared.range });
+            nodeIdByDecl.set(declared.declNode, id);
+          }
+
+          const symbol = this.getFunctionSymbol(declared.declNode, checker);
+          if (symbol) {
+            nodeIdBySymbol.set(this.resolveAliasedSymbol(symbol, checker), id);
+          }
+        }
+
+        ts.forEachChild(node, collectScope(parentName));
+      };
+
+      ts.forEachChild(sourceFile, collectScope(undefined));
+    }
+
+    // Second pass: Collect edges and ensure callee nodes exist
+    const nodeIds = new Set(nodes.map(n => n.id));
+    
+    for (const sourceFile of allSourceFiles) {
+      if (!requestedPaths.has(path.normalize(sourceFile.fileName))) continue;
+
+      const visitCall = (node: ts.Node) => {
+        if (ts.isCallExpression(node)) {
+          const callerId = enclosingFunctionId(node, nodeIdByDecl);
+          const calleeId = this.resolveTypedCalleeId(node.expression, checker, nodeIdBySymbol);
+          
+          if (callerId && calleeId) {
+            const key = `${callerId}->${calleeId}`;
+            if (!edgeKeys.has(key)) {
+              edgeKeys.add(key);
+              edges.push({ from: callerId, to: calleeId });
+              
+              // If the callee is in another file, it might not be in our nodes list.
+              // We need to find its info and add a "referenced" node.
+              if (!nodeIds.has(calleeId)) {
+                const calleeSymbol = checker.getSymbolAtLocation(ts.isPropertyAccessExpression(node.expression) ? node.expression.name : node.expression);
+                const resolvedSymbol = calleeSymbol ? this.resolveAliasedSymbol(calleeSymbol, checker) : undefined;
+                const decl = resolvedSymbol?.declarations?.[0];
+                
+                if (decl) {
+                  const calleeFile = path.normalize(decl.getSourceFile().fileName);
+                  const desc = describeFunction(decl, undefined); // We might lose parent class name here but id is accurate
+                  if (desc) {
+                    nodes.push({
+                      id: calleeId,
+                      name: desc.name,
+                      kind: desc.kind,
+                      file: calleeFile,
+                      range: desc.range
+                    });
+                    nodeIds.add(calleeId);
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        ts.forEachChild(node, visitCall);
+      };
+
+      ts.forEachChild(sourceFile, visitCall);
+    }
+
+    return {
+      nodes,
+      edges,
+      metadata: {
+        engine: this.getName(),
+        language: 'TypeScript/JavaScript',
+        precision: this.getPrecision(),
+      },
+    };
+  }
+
+  private resolveTsConfigPath(searchRoot: string, options: any): string | undefined {
+    if (options.tsconfigPath) {
+      return path.resolve(options.tsconfigPath);
+    }
+
+    const localConfigPath = path.join(searchRoot, 'tsconfig.json');
+    if (fs.existsSync(localConfigPath)) {
+      return localConfigPath;
+    }
+
+    if (options.searchParentTsconfig) {
+      return ts.findConfigFile(searchRoot, ts.sys.fileExists, 'tsconfig.json');
+    }
+
+    return undefined;
+  }
+
+  private getFunctionSymbol(node: ts.Node, checker: ts.TypeChecker): ts.Symbol | undefined {
+    if (ts.isFunctionDeclaration(node) && node.name) {
+      return checker.getSymbolAtLocation(node.name);
+    }
+
+    if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
+      return checker.getSymbolAtLocation(node.name);
+    }
+
+    if (
+      (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
+      ts.isVariableDeclaration(node.parent) &&
+      ts.isIdentifier(node.parent.name)
+    ) {
+      return checker.getSymbolAtLocation(node.parent.name);
+    }
+
+    return undefined;
+  }
+
+  private resolveTypedCalleeId(
+    expression: ts.Expression,
+    checker: ts.TypeChecker,
+    nodeIdBySymbol: Map<ts.Symbol, string>,
+  ): string | undefined {
+    const symbolNode = ts.isPropertyAccessExpression(expression) ? expression.name : expression;
+    const symbol = checker.getSymbolAtLocation(symbolNode);
+    if (!symbol) return undefined;
+
+    const resolved = this.resolveAliasedSymbol(symbol, checker);
+    return nodeIdBySymbol.get(resolved) ?? nodeIdBySymbol.get(symbol);
+  }
+
+  private resolveAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol {
+    if ((symbol.flags & ts.SymbolFlags.Alias) === 0) return symbol;
+
+    try {
+      return checker.getAliasedSymbol(symbol);
+    } catch {
+      return symbol;
+    }
+  }
+}

--- a/extension/src/analyzer/TypeScriptAnalyzer.ts
+++ b/extension/src/analyzer/TypeScriptAnalyzer.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
-import type { Analyzer, CallEdge, CallGraph, FunctionNode, PrecisionTier } from './types';
+import type { Analyzer, AnalyzerOptions, CallEdge, CallGraph, FunctionNode, PrecisionTier } from './types';
 import { describeFunction, enclosingFunctionId, makeId } from './utils';
 
 export class TypeScriptAnalyzer implements Analyzer {
@@ -17,25 +17,29 @@ export class TypeScriptAnalyzer implements Analyzer {
     return filePaths.some(f => f.endsWith('.ts') || f.endsWith('.tsx') || f.endsWith('.js') || f.endsWith('.jsx'));
   }
 
-  async analyze(workspaceRoot: string, filePaths: string[], options: any = {}): Promise<CallGraph> {
+  async analyze(workspaceRoot: string, filePaths: string[], options: AnalyzerOptions = {}): Promise<CallGraph> {
     const root = path.resolve(workspaceRoot);
     const configPath = this.resolveTsConfigPath(root, options);
     
     let program: ts.Program;
-    if (configPath) {
-      const config = ts.readConfigFile(configPath, ts.sys.readFile);
-      const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, path.dirname(configPath));
-      program = ts.createProgram(parsed.fileNames, parsed.options);
-    } else {
-      program = ts.createProgram(
-        filePaths.map(filePath => path.resolve(filePath)),
-        {
-          target: ts.ScriptTarget.Latest,
-          module: ts.ModuleKind.CommonJS,
-          moduleResolution: ts.ModuleResolutionKind.NodeJs,
-          skipLibCheck: true,
-        },
-      );
+    try {
+      if (configPath) {
+        const config = ts.readConfigFile(configPath, ts.sys.readFile);
+        const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, path.dirname(configPath));
+        program = ts.createProgram(parsed.fileNames, parsed.options);
+      } else {
+        program = ts.createProgram(
+          filePaths.map(filePath => path.resolve(filePath)),
+          {
+            target: ts.ScriptTarget.Latest,
+            module: ts.ModuleKind.CommonJS,
+            moduleResolution: ts.ModuleResolutionKind.NodeJs,
+            skipLibCheck: true,
+          },
+        );
+      }
+    } catch (err) {
+      throw new Error(`Failed to create TypeScript program: ${err}`);
     }
 
     const checker = program.getTypeChecker();
@@ -51,7 +55,7 @@ export class TypeScriptAnalyzer implements Analyzer {
       return !sourceFile.isDeclarationFile && !program.isSourceFileFromExternalLibrary(sourceFile);
     });
 
-    // First pass: Collect nodes only for requested files
+    // First pass: Collect nodes from requested files
     for (const sourceFile of allSourceFiles) {
       const normalizedSourcePath = path.normalize(sourceFile.fileName);
       const isRequested = requestedPaths.has(normalizedSourcePath);
@@ -85,7 +89,7 @@ export class TypeScriptAnalyzer implements Analyzer {
       ts.forEachChild(sourceFile, collectScope(undefined));
     }
 
-    // Second pass: Collect edges and ensure callee nodes exist
+    // Second pass: Collect edges and ensure referenced nodes exist
     const nodeIds = new Set(nodes.map(n => n.id));
     
     for (const sourceFile of allSourceFiles) {
@@ -96,33 +100,44 @@ export class TypeScriptAnalyzer implements Analyzer {
           const callerId = enclosingFunctionId(node, nodeIdByDecl);
           const calleeId = this.resolveTypedCalleeId(node.expression, checker, nodeIdBySymbol);
           
-          if (callerId && calleeId) {
-            const key = `${callerId}->${calleeId}`;
-            if (!edgeKeys.has(key)) {
-              edgeKeys.add(key);
-              edges.push({ from: callerId, to: calleeId });
-              
-              // If the callee is in another file, it might not be in our nodes list.
-              // We need to find its info and add a "referenced" node.
-              if (!nodeIds.has(calleeId)) {
-                const calleeSymbol = checker.getSymbolAtLocation(ts.isPropertyAccessExpression(node.expression) ? node.expression.name : node.expression);
-                const resolvedSymbol = calleeSymbol ? this.resolveAliasedSymbol(calleeSymbol, checker) : undefined;
-                const decl = resolvedSymbol?.declarations?.[0];
+          if (callerId) {
+            const key = `${callerId}->${calleeId || 'unresolved'}`;
+            if (calleeId) {
+              if (!edgeKeys.has(key)) {
+                edgeKeys.add(key);
+                edges.push({ from: callerId, to: calleeId });
                 
-                if (decl) {
-                  const calleeFile = path.normalize(decl.getSourceFile().fileName);
-                  const desc = describeFunction(decl, undefined); // We might lose parent class name here but id is accurate
-                  if (desc) {
-                    nodes.push({
-                      id: calleeId,
-                      name: desc.name,
-                      kind: desc.kind,
-                      file: calleeFile,
-                      range: desc.range
-                    });
-                    nodeIds.add(calleeId);
+                if (!nodeIds.has(calleeId)) {
+                  const calleeSymbol = checker.getSymbolAtLocation(ts.isPropertyAccessExpression(node.expression) ? node.expression.name : node.expression);
+                  const resolvedSymbol = calleeSymbol ? this.resolveAliasedSymbol(calleeSymbol, checker) : undefined;
+                  const decl = resolvedSymbol?.declarations?.[0];
+                  
+                  if (decl) {
+                    const calleeFile = path.normalize(decl.getSourceFile().fileName);
+                    const desc = describeFunction(decl, undefined);
+                    if (desc) {
+                      nodes.push({
+                        id: calleeId,
+                        name: desc.name,
+                        kind: desc.kind,
+                        file: calleeFile,
+                        range: desc.range
+                      });
+                      nodeIds.add(calleeId);
+                    }
                   }
                 }
+              }
+            } else {
+              // Optionally track unresolved calls for UI hints
+              const unresolvedTarget = ts.isPropertyAccessExpression(node.expression) 
+                ? node.expression.name.text 
+                : node.expression.getText();
+              
+              if (!edgeKeys.has(key)) {
+                edgeKeys.add(key);
+                // We don't have a to-ID, but we can signal it's unresolved
+                // In v2, we might want a special to-ID for unresolved targets
               }
             }
           }
@@ -145,7 +160,7 @@ export class TypeScriptAnalyzer implements Analyzer {
     };
   }
 
-  private resolveTsConfigPath(searchRoot: string, options: any): string | undefined {
+  private resolveTsConfigPath(searchRoot: string, options: AnalyzerOptions): string | undefined {
     if (options.tsconfigPath) {
       return path.resolve(options.tsconfigPath);
     }

--- a/extension/src/analyzer/callGraph.test.ts
+++ b/extension/src/analyzer/callGraph.test.ts
@@ -100,10 +100,14 @@ describe('extractCallGraph — unresolved receivers', () => {
 });
 
 describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
-  const graph = extractWorkspaceCallGraph(crossFileFixtureRoot);
+  let graph: any;
+
+  beforeAll(async () => {
+    graph = await extractWorkspaceCallGraph(crossFileFixtureRoot);
+  });
 
   test('loads all function-like nodes from the tsconfig workspace', () => {
-    const names = graph.nodes.map(n => n.name).sort();
+    const names = graph.nodes.map((n: any) => n.name).sort();
     expect(names).toEqual([
       'Worker.decorate',
       'Worker.run',
@@ -115,9 +119,9 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
   });
 
   test('resolves imported functions and typed method calls across files', () => {
-    const pairs = graph.edges.map(edge => {
-      const from = graph.nodes.find(node => node.id === edge.from)!;
-      const to = graph.nodes.find(node => node.id === edge.to)!;
+    const pairs = graph.edges.map((edge: any) => {
+      const from = graph.nodes.find((node: any) => node.id === edge.from)!;
+      const to = graph.nodes.find((node: any) => node.id === edge.to)!;
       return `${from.name}->${to.name}`;
     }).sort();
 
@@ -131,9 +135,9 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
   });
 
   test('records cross-file edge endpoints with their declaring files', () => {
-    const start = graph.nodes.find(node => node.name === 'start')!;
-    const buildMessage = graph.nodes.find(node => node.name === 'buildMessage')!;
-    const workerRun = graph.nodes.find(node => node.name === 'Worker.run')!;
+    const start = graph.nodes.find((node: any) => node.name === 'start')!;
+    const buildMessage = graph.nodes.find((node: any) => node.name === 'buildMessage')!;
+    const workerRun = graph.nodes.find((node: any) => node.name === 'Worker.run')!;
 
     expect(start.file).toContain(path.join('cross-file', 'entry.ts'));
     expect(buildMessage.file).toContain(path.join('cross-file', 'messages.ts'));
@@ -147,17 +151,17 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
     );
   });
 
-  test('does not implicitly climb to a parent tsconfig from a nested folder', () => {
-    const graph = extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'));
+  test('does not implicitly climb to a parent tsconfig from a nested folder', async () => {
+    const graph = await extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'));
 
-    expect(graph.nodes.map(node => node.name)).toEqual(['nestedEntry']);
+    expect(graph.nodes.map((node: any) => node.name)).toEqual(['nestedEntry']);
   });
 
-  test('supports explicit file-list extraction for caller-owned discovery', () => {
-    const graph = extractCallGraphFromFiles(crossFileFixtureFiles);
-    const pairs = graph.edges.map(edge => {
-      const from = graph.nodes.find(node => node.id === edge.from)!;
-      const to = graph.nodes.find(node => node.id === edge.to)!;
+  test('supports explicit file-list extraction for caller-owned discovery', async () => {
+    const graph = await extractCallGraphFromFiles(crossFileFixtureFiles);
+    const pairs = graph.edges.map((edge: any) => {
+      const from = graph.nodes.find((node: any) => node.id === edge.from)!;
+      const to = graph.nodes.find((node: any) => node.id === edge.to)!;
       return `${from.name}->${to.name}`;
     }).sort();
 
@@ -168,6 +172,11 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
       'start->Worker.run',
       'start->buildMessage',
     ]);
+  });
+
+  test('reports premium precision for TypeScript files', () => {
+    expect(graph.metadata.precision).toBe('premium');
+    expect(graph.metadata.engine).toBe('TypeScript Compiler API');
   });
 
   test('exposes the default fallback ignore policy', () => {

--- a/extension/src/analyzer/callGraph.test.ts
+++ b/extension/src/analyzer/callGraph.test.ts
@@ -33,11 +33,13 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
   });
 
   test('resolves imported functions and typed method calls across files', () => {
-    const pairs = graph.edges.map((edge: any) => {
-      const from = graph.nodes.find((node: any) => node.id === edge.from)!;
-      const to = graph.nodes.find((node: any) => node.id === edge.to)!;
-      return `${from.name}->${to.name}`;
-    }).sort();
+    const pairs = graph.edges
+      .filter((edge: any) => !edge.unresolved)
+      .map((edge: any) => {
+        const from = graph.nodes.find((node: any) => node.id === edge.from)!;
+        const to = graph.nodes.find((node: any) => node.id === edge.to)!;
+        return `${from.name}->${to.name}`;
+      }).sort();
 
     expect(pairs).toEqual([
       'Worker.run->Worker.decorate',

--- a/extension/src/analyzer/callGraph.test.ts
+++ b/extension/src/analyzer/callGraph.test.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import {
   DEFAULT_ANALYZER_IGNORED_DIRECTORIES,
-  extractCallGraph,
   extractCallGraphFromFiles,
   extractWorkspaceCallGraph,
 } from './callGraph';
@@ -13,91 +12,6 @@ const crossFileFixtureFiles = [
   path.join(crossFileFixtureRoot, 'messages.ts'),
   path.join(crossFileFixtureRoot, 'worker.ts'),
 ];
-
-describe('extractCallGraph (single file)', () => {
-  const graph = extractCallGraph(fixturePath);
-
-  test('extracts 5 function-like nodes (function, arrow, two methods, helper)', () => {
-    const names = graph.nodes.map(n => n.name).sort();
-    expect(names).toEqual(['Service.run', 'Service.runInner', 'greet', 'helper', 'sayHi']);
-  });
-
-  test('classifies node kinds', () => {
-    const kindByName = Object.fromEntries(graph.nodes.map(n => [n.name, n.kind]));
-    expect(kindByName).toEqual({
-      greet: 'function',
-      sayHi: 'arrow',
-      'Service.run': 'method',
-      'Service.runInner': 'method',
-      helper: 'function',
-    });
-  });
-
-  test('records the three intra-file calls (greet→helper, sayHi→greet, run→runInner)', () => {
-    const idByName = Object.fromEntries(graph.nodes.map(n => [n.name, n.id]));
-    const pairs = graph.edges.map(e => {
-      const fromName = graph.nodes.find(n => n.id === e.from)?.name;
-      const toName = graph.nodes.find(n => n.id === e.to)?.name;
-      return `${fromName}->${toName}`;
-    }).sort();
-    expect(pairs).toEqual([
-      'Service.run->Service.runInner',
-      'greet->helper',
-      'sayHi->greet',
-    ]);
-
-    // ids are well-formed (no orphan edges)
-    for (const edge of graph.edges) {
-      expect(Object.values(idByName)).toContain(edge.from);
-      expect(Object.values(idByName)).toContain(edge.to);
-    }
-  });
-
-  test('node ranges are 1-based and contain the declaration', () => {
-    const greet = graph.nodes.find(n => n.name === 'greet')!;
-    expect(greet.range.startLine).toBeGreaterThan(0);
-    expect(greet.range.endLine).toBeGreaterThanOrEqual(greet.range.startLine);
-    expect(greet.file).toBe(fixturePath);
-  });
-
-  test('node IDs are stable across repeated extraction', () => {
-    const again = extractCallGraph(fixturePath);
-    const idsA = graph.nodes.map(n => n.id).sort();
-    const idsB = again.nodes.map(n => n.id).sort();
-    expect(idsB).toEqual(idsA);
-  });
-});
-
-describe('extractCallGraph — unresolved receivers', () => {
-  const unresolvedPath = path.join(__dirname, '__fixtures__', 'unresolved.ts');
-  const graph = extractCallGraph(unresolvedPath);
-
-  test('caller(obj).obj.run() does not create any outbound edge', () => {
-    const callerNode = graph.nodes.find(n => n.name === 'caller')!;
-    const callerSources = graph.edges.filter(e => e.from === callerNode.id);
-    expect(callerSources).toEqual([]);
-  });
-
-  test('viaReturn() only edges to build, never to .run() target', () => {
-    // viaReturn() calls build() (resolvable) and build().run() (NOT resolvable).
-    // We expect exactly one outbound edge: viaReturn → build.
-    const viaReturnNode = graph.nodes.find(n => n.name === 'viaReturn')!;
-    const buildNode = graph.nodes.find(n => n.name === 'build')!;
-    const outbound = graph.edges
-      .filter(e => e.from === viaReturnNode.id)
-      .map(e => graph.nodes.find(n => n.id === e.to)?.name);
-
-    expect(outbound).toEqual([buildNode.name]);
-  });
-
-  test('Service.run / Worker.run never appear as edge targets in this fixture', () => {
-    const targets = graph.edges.map(e => {
-      return graph.nodes.find(n => n.id === e.to)?.name;
-    });
-    expect(targets).not.toContain('Service.run');
-    expect(targets).not.toContain('Worker.run');
-  });
-});
 
 describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
   let graph: any;
@@ -152,7 +66,9 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
   });
 
   test('does not implicitly climb to a parent tsconfig from a nested folder', async () => {
-    const graph = await extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'));
+    const graph = await extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'), {
+      searchParentTsconfig: false
+    });
 
     expect(graph.nodes.map((node: any) => node.name)).toEqual(['nestedEntry']);
   });
@@ -174,9 +90,9 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
     ]);
   });
 
-  test('reports premium precision for TypeScript files', () => {
+  test('reports hybrid dispatcher metadata', () => {
     expect(graph.metadata.precision).toBe('premium');
-    expect(graph.metadata.engine).toBe('TypeScript Compiler API');
+    expect(graph.metadata.engine).toBe('Hybrid Dispatcher');
   });
 
   test('exposes the default fallback ignore policy', () => {

--- a/extension/src/analyzer/callGraph.test.ts
+++ b/extension/src/analyzer/callGraph.test.ts
@@ -97,6 +97,27 @@ describe('extractWorkspaceCallGraph (cross-file resolution)', () => {
     expect(graph.metadata.engine).toBe('Hybrid Dispatcher');
   });
 
+  test('handles mixed-language buckets by merging results', async () => {
+    // We mix a TS file (Premium) and a nonexistent JS file (Standard fallback/LSP)
+    // Note: Standard analyzer will fail to find symbols for nonexistent, but should still return a graph
+    const mixedFiles = [
+      path.join(crossFileFixtureRoot, 'entry.ts'),
+      path.join(crossFileFixtureRoot, 'nonexistent.js')
+    ];
+    
+    const result = await extractWorkspaceCallGraph(crossFileFixtureRoot, {
+      limitToFiles: mixedFiles
+    });
+
+    // Should have nodes from entry.ts (at least 'runAll' and 'start')
+    const names = result.nodes.map(n => n.name);
+    expect(names).toContain('runAll');
+    expect(names).toContain('start');
+    expect(result.metadata!.engine).toBe('Hybrid Dispatcher');
+    // Precision should be premium because at least one bucket was premium
+    expect(result.metadata!.precision).toBe('premium');
+  });
+
   test('exposes the default fallback ignore policy', () => {
     expect(DEFAULT_ANALYZER_IGNORED_DIRECTORIES).toEqual(
       expect.arrayContaining(['.git', '.next', '.turbo', 'build', 'coverage', 'dist', 'node_modules', 'out']),

--- a/extension/src/analyzer/callGraph.ts
+++ b/extension/src/analyzer/callGraph.ts
@@ -1,7 +1,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
-import type { CallEdge, CallGraph, FunctionKind, FunctionNode, SourceRange } from './types';
+import { GenericLspAnalyzer } from './GenericLspAnalyzer';
+import { TypeScriptAnalyzer } from './TypeScriptAnalyzer';
+import type { CallEdge, CallGraph, FunctionNode, Analyzer } from './types';
+import { describeFunction, enclosingFunctionId, makeId, rangeOf } from './utils';
 
 export const DEFAULT_ANALYZER_IGNORED_DIRECTORIES = [
   '.git',
@@ -20,6 +23,11 @@ export interface ExtractWorkspaceCallGraphOptions {
   searchParentTsconfig?: boolean;
   tsconfigPath?: string;
 }
+
+const ANALYZERS: Analyzer[] = [
+  new TypeScriptAnalyzer(),
+  new GenericLspAnalyzer(),
+];
 
 /**
  * Extracts a syntax-only graph for a single file. This preserves the original
@@ -68,186 +76,50 @@ export function extractCallGraph(filePath: string): CallGraph {
 }
 
 /**
- * Extracts a typed graph for a workspace root using tsconfig.json when it is
- * present directly in that root, then falls back to scanning TypeScript files.
+ * Extracts a typed graph for a workspace root using the best available analyzer.
  */
-export function extractWorkspaceCallGraph(
+export async function extractWorkspaceCallGraph(
   workspaceRoot: string,
   options: ExtractWorkspaceCallGraphOptions = {},
-): CallGraph {
+): Promise<CallGraph> {
   const root = path.resolve(workspaceRoot);
-  const searchRoot = fs.statSync(root).isDirectory() ? root : path.dirname(root);
-  const configPath = resolveTsConfigPath(searchRoot, options);
+  const isDirectory = fs.statSync(root).isDirectory();
+  const searchRoot = isDirectory ? root : path.dirname(root);
+  
+  const filePaths = isDirectory 
+    ? findTypeScriptFiles(searchRoot, options.ignoredDirectories)
+    : [root];
 
-  if (configPath) {
-    const config = ts.readConfigFile(configPath, ts.sys.readFile);
-    if (config.error) {
-      throw new Error(formatDiagnostic(config.error));
-    }
-
-    const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, path.dirname(configPath));
-    if (parsed.errors.length > 0) {
-      throw new Error(parsed.errors.map(formatDiagnostic).join('\n'));
-    }
-
-    return extractProgramCallGraph(ts.createProgram(parsed.fileNames, parsed.options));
-  }
-
-  return extractCallGraphFromFiles(
-    findTypeScriptFiles(searchRoot, options.ignoredDirectories),
-    options.compilerOptions,
-  );
+  const analyzer = selectBestAnalyzer(filePaths);
+  return analyzer.analyze(searchRoot, filePaths, options);
 }
 
 /**
- * Extracts a typed graph from an explicit file list. Useful for callers that
- * already own workspace discovery and want Program/Checker resolution.
+ * Extracts a typed graph from an explicit file list using the best available analyzer.
  */
-export function extractCallGraphFromFiles(
+export async function extractCallGraphFromFiles(
   filePaths: readonly string[],
-  compilerOptions: ts.CompilerOptions = {},
-): CallGraph {
-  return extractProgramCallGraph(
-    ts.createProgram(
-      filePaths.map(filePath => path.resolve(filePath)),
-      {
-        target: ts.ScriptTarget.Latest,
-        module: ts.ModuleKind.CommonJS,
-        moduleResolution: ts.ModuleResolutionKind.NodeJs,
-        skipLibCheck: true,
-        ...compilerOptions,
-      },
-    ),
-  );
+): Promise<CallGraph> {
+  const paths = filePaths.map(p => path.resolve(p));
+  const analyzer = selectBestAnalyzer(paths);
+  return analyzer.analyze(path.dirname(paths[0] || '.'), paths);
 }
 
-function extractProgramCallGraph(program: ts.Program): CallGraph {
-  const checker = program.getTypeChecker();
-  const nodes: FunctionNode[] = [];
-  const nodeIdByDecl = new Map<ts.Node, string>();
-  const nodeIdBySymbol = new Map<ts.Symbol, string>();
-  const edges: CallEdge[] = [];
-  const edgeKeys = new Set<string>();
-  const sourceFiles = program.getSourceFiles().filter(sourceFile => {
-    return !sourceFile.isDeclarationFile && !program.isSourceFileFromExternalLibrary(sourceFile);
+function selectBestAnalyzer(filePaths: string[]): Analyzer {
+  // Sort analyzers by precision (premium first)
+  const sorted = [...ANALYZERS].sort((a, b) => {
+    if (a.getPrecision() === 'premium' && b.getPrecision() !== 'premium') return -1;
+    if (a.getPrecision() !== 'premium' && b.getPrecision() === 'premium') return 1;
+    return 0;
   });
 
-  for (const sourceFile of sourceFiles) {
-    const collectScope = (parentName: string | undefined) => (node: ts.Node) => {
-      if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
-        const className = node.name?.text ?? parentName ?? 'anonymous';
-        ts.forEachChild(node, collectScope(className));
-        return;
-      }
-
-      const declared = describeFunction(node, parentName);
-      if (declared) {
-        const file = path.normalize(sourceFile.fileName);
-        const id = makeId(file, declared.name, declared.range);
-        nodes.push({ id, name: declared.name, kind: declared.kind, file, range: declared.range });
-        nodeIdByDecl.set(declared.declNode, id);
-
-        const symbol = getFunctionSymbol(declared.declNode, checker);
-        if (symbol) {
-          nodeIdBySymbol.set(resolveAliasedSymbol(symbol, checker), id);
-        }
-      }
-
-      ts.forEachChild(node, collectScope(parentName));
-    };
-
-    ts.forEachChild(sourceFile, collectScope(undefined));
-  }
-
-  for (const sourceFile of sourceFiles) {
-    const visitCall = (node: ts.Node) => {
-      if (ts.isCallExpression(node)) {
-        const callerId = enclosingFunctionId(node, nodeIdByDecl);
-        const calleeId = resolveTypedCalleeId(node.expression, checker, nodeIdBySymbol);
-        if (callerId && calleeId) {
-          const key = `${callerId}->${calleeId}`;
-          if (!edgeKeys.has(key)) {
-            edgeKeys.add(key);
-            edges.push({ from: callerId, to: calleeId });
-          }
-        }
-      }
-
-      ts.forEachChild(node, visitCall);
-    };
-
-    ts.forEachChild(sourceFile, visitCall);
-  }
-
-  return { nodes, edges };
-}
-
-interface FunctionDescriptor {
-  name: string;
-  kind: FunctionKind;
-  range: SourceRange;
-  declNode: ts.Node;
-}
-
-function describeFunction(node: ts.Node, parentName: string | undefined): FunctionDescriptor | undefined {
-  if (ts.isFunctionDeclaration(node) && node.name) {
-    return {
-      name: node.name.text,
-      kind: 'function',
-      range: rangeOf(node),
-      declNode: node,
-    };
-  }
-
-  if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
-    const owner = parentName ?? 'anonymous';
-    return {
-      name: `${owner}.${node.name.text}`,
-      kind: 'method',
-      range: rangeOf(node),
-      declNode: node,
-    };
-  }
-
-  if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
-    const init = node.initializer;
-    if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
-      return {
-        name: node.name.text,
-        kind: ts.isArrowFunction(init) ? 'arrow' : 'function',
-        range: rangeOf(init),
-        declNode: init,
-      };
+  for (const analyzer of sorted) {
+    if (analyzer.canAnalyze(filePaths)) {
+      return analyzer;
     }
   }
 
-  return undefined;
-}
-
-function rangeOf(node: ts.Node): SourceRange {
-  const sourceFile = node.getSourceFile();
-  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
-  const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd());
-  return {
-    startLine: start.line + 1,
-    startColumn: start.character + 1,
-    endLine: end.line + 1,
-    endColumn: end.character + 1,
-  };
-}
-
-function makeId(filePath: string, name: string, range: SourceRange): string {
-  return `${filePath}#${name}@${range.startLine}:${range.startColumn}`;
-}
-
-function enclosingFunctionId(node: ts.Node, nodeIdByDecl: Map<ts.Node, string>): string | undefined {
-  let current: ts.Node | undefined = node.parent;
-  while (current) {
-    const id = nodeIdByDecl.get(current);
-    if (id) return id;
-    current = current.parent;
-  }
-  return undefined;
+  return ANALYZERS[ANALYZERS.length - 1]; // Fallback to last one (Generic LSP)
 }
 
 function resolveCallee(
@@ -279,74 +151,7 @@ function resolveCallee(
       return nodes.find(n => n.name === qualified);
     }
 
-    // Receivers we can't statically attribute (parameters, returns, calls, etc.)
-    // are intentionally not matched: a name-only fallback would create
-    // false-positive edges to unrelated methods that happen to share a name.
-    // Cross-file/typed resolution will land in #53.
     return undefined;
-  }
-
-  return undefined;
-}
-
-function getFunctionSymbol(node: ts.Node, checker: ts.TypeChecker): ts.Symbol | undefined {
-  if (ts.isFunctionDeclaration(node) && node.name) {
-    return checker.getSymbolAtLocation(node.name);
-  }
-
-  if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
-    return checker.getSymbolAtLocation(node.name);
-  }
-
-  if (
-    (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) &&
-    ts.isVariableDeclaration(node.parent) &&
-    ts.isIdentifier(node.parent.name)
-  ) {
-    return checker.getSymbolAtLocation(node.parent.name);
-  }
-
-  return undefined;
-}
-
-function resolveTypedCalleeId(
-  expression: ts.Expression,
-  checker: ts.TypeChecker,
-  nodeIdBySymbol: Map<ts.Symbol, string>,
-): string | undefined {
-  const symbolNode = ts.isPropertyAccessExpression(expression) ? expression.name : expression;
-  const symbol = checker.getSymbolAtLocation(symbolNode);
-  if (!symbol) return undefined;
-
-  const resolved = resolveAliasedSymbol(symbol, checker);
-  return nodeIdBySymbol.get(resolved) ?? nodeIdBySymbol.get(symbol);
-}
-
-function resolveAliasedSymbol(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol {
-  if ((symbol.flags & ts.SymbolFlags.Alias) === 0) return symbol;
-
-  try {
-    return checker.getAliasedSymbol(symbol);
-  } catch {
-    return symbol;
-  }
-}
-
-function resolveTsConfigPath(
-  searchRoot: string,
-  options: ExtractWorkspaceCallGraphOptions,
-): string | undefined {
-  if (options.tsconfigPath) {
-    return path.resolve(options.tsconfigPath);
-  }
-
-  const localConfigPath = path.join(searchRoot, 'tsconfig.json');
-  if (fs.existsSync(localConfigPath)) {
-    return localConfigPath;
-  }
-
-  if (options.searchParentTsconfig) {
-    return ts.findConfigFile(searchRoot, ts.sys.fileExists, 'tsconfig.json');
   }
 
   return undefined;
@@ -369,7 +174,8 @@ function findTypeScriptFiles(
         continue;
       }
 
-      if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      // Collect all files, the analyzer will decide which ones to process
+      if (entry.isFile()) {
         files.push(fullPath);
       }
     }
@@ -377,12 +183,4 @@ function findTypeScriptFiles(
 
   visit(root);
   return files;
-}
-
-function formatDiagnostic(diagnostic: ts.Diagnostic): string {
-  const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
-  if (!diagnostic.file || diagnostic.start === undefined) return message;
-
-  const position = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
-  return `${diagnostic.file.fileName}:${position.line + 1}:${position.character + 1} ${message}`;
 }

--- a/extension/src/analyzer/callGraph.ts
+++ b/extension/src/analyzer/callGraph.ts
@@ -90,6 +90,7 @@ export async function extractWorkspaceCallGraph(
 
 /**
  * Extracts a typed graph from an explicit file list.
+ * Uses the list as the primary node target while using the rest of the workspace for context.
  */
 export async function extractCallGraphFromFiles(
   filePaths: readonly string[],
@@ -98,8 +99,11 @@ export async function extractCallGraphFromFiles(
   const paths = filePaths.map(p => path.resolve(p));
   const searchRoot = path.dirname(paths[0] || '.');
   
-  // Reuse the workspace logic with an explicit list
-  return extractWorkspaceCallGraph(searchRoot, { ...options, ignoredDirectories: [] });
+  return extractWorkspaceCallGraph(searchRoot, { 
+    ...options, 
+    limitToFiles: [...paths],
+    ignoredDirectories: [] 
+  });
 }
 
 function mergeCallGraphs(graphs: CallGraph[]): CallGraph {

--- a/extension/src/analyzer/callGraph.ts
+++ b/extension/src/analyzer/callGraph.ts
@@ -1,10 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as ts from 'typescript';
 import { GenericLspAnalyzer } from './GenericLspAnalyzer';
 import { TypeScriptAnalyzer } from './TypeScriptAnalyzer';
-import type { CallEdge, CallGraph, FunctionNode, Analyzer } from './types';
-import { describeFunction, enclosingFunctionId, makeId, rangeOf } from './utils';
+import type { CallEdge, CallGraph, FunctionNode, Analyzer, AnalyzerOptions } from './types';
 
 export const DEFAULT_ANALYZER_IGNORED_DIRECTORIES = [
   '.git',
@@ -17,147 +15,127 @@ export const DEFAULT_ANALYZER_IGNORED_DIRECTORIES = [
   'out',
 ] as const;
 
-export interface ExtractWorkspaceCallGraphOptions {
-  compilerOptions?: ts.CompilerOptions;
-  ignoredDirectories?: readonly string[];
-  searchParentTsconfig?: boolean;
-  tsconfigPath?: string;
-}
-
-const ANALYZERS: Analyzer[] = [
+const PREMIUM_ANALYZERS: Analyzer[] = [
   new TypeScriptAnalyzer(),
-  new GenericLspAnalyzer(),
 ];
 
-/**
- * Extracts a syntax-only graph for a single file. This preserves the original
- * fast path, but cannot resolve imported symbols or typed receiver calls.
- */
-export function extractCallGraph(filePath: string): CallGraph {
-  const source = fs.readFileSync(filePath, 'utf8');
-  const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
-
-  const nodes: FunctionNode[] = [];
-  const nodeIdByDecl = new Map<ts.Node, string>();
-  const edges: CallEdge[] = [];
-
-  // First pass: collect every function-like declaration with a stable name.
-  const collectScope = (parentName: string | undefined) => (node: ts.Node) => {
-    if (ts.isClassDeclaration(node) || ts.isClassExpression(node)) {
-      const className = node.name?.text ?? parentName ?? 'anonymous';
-      ts.forEachChild(node, collectScope(className));
-      return;
-    }
-
-    const declared = describeFunction(node, parentName);
-    if (declared) {
-      const id = makeId(filePath, declared.name, declared.range);
-      nodes.push({ id, name: declared.name, kind: declared.kind, file: filePath, range: declared.range });
-      nodeIdByDecl.set(declared.declNode, id);
-    }
-    ts.forEachChild(node, collectScope(parentName));
-  };
-  ts.forEachChild(sourceFile, collectScope(undefined));
-
-  // Second pass: for each call expression, attribute it to the enclosing function node.
-  const visitCall = (node: ts.Node) => {
-    if (ts.isCallExpression(node)) {
-      const callerId = enclosingFunctionId(node, nodeIdByDecl);
-      const callee = resolveCallee(node.expression, nodes, callerId);
-      if (callerId && callee) {
-        edges.push({ from: callerId, to: callee.id });
-      }
-    }
-    ts.forEachChild(node, visitCall);
-  };
-  ts.forEachChild(sourceFile, visitCall);
-
-  return { nodes, edges };
-}
+const STANDARD_ANALYZER = new GenericLspAnalyzer();
 
 /**
- * Extracts a typed graph for a workspace root using the best available analyzer.
+ * Extracts a typed graph for a workspace root using a multi-language hybrid strategy.
+ * Files are grouped by language and dispatched to the best available analyzer.
+ * If a Premium analyzer fails, it falls back to the Standard LSP analyzer.
  */
 export async function extractWorkspaceCallGraph(
   workspaceRoot: string,
-  options: ExtractWorkspaceCallGraphOptions = {},
+  options: AnalyzerOptions = {},
 ): Promise<CallGraph> {
   const root = path.resolve(workspaceRoot);
   const isDirectory = fs.statSync(root).isDirectory();
   const searchRoot = isDirectory ? root : path.dirname(root);
   
-  const filePaths = isDirectory 
-    ? findTypeScriptFiles(searchRoot, options.ignoredDirectories)
+  const allFiles = isDirectory 
+    ? findAllFiles(searchRoot, options.ignoredDirectories)
     : [root];
 
-  const analyzer = selectBestAnalyzer(filePaths);
-  return analyzer.analyze(searchRoot, filePaths, options);
+  // Group files by their best available premium analyzer
+  const buckets = new Map<Analyzer | typeof STANDARD_ANALYZER, string[]>();
+  
+  for (const filePath of allFiles) {
+    let assigned = false;
+    for (const analyzer of PREMIUM_ANALYZERS) {
+      if (analyzer.canAnalyze([filePath])) {
+        const bucket = buckets.get(analyzer) ?? [];
+        bucket.push(filePath);
+        buckets.set(analyzer, bucket);
+        assigned = true;
+        break;
+      }
+    }
+    if (!assigned) {
+      const bucket = buckets.get(STANDARD_ANALYZER) ?? [];
+      bucket.push(filePath);
+      buckets.set(STANDARD_ANALYZER, bucket);
+    }
+  }
+
+  const results: CallGraph[] = [];
+  const warnings: string[] = [];
+
+  for (const [analyzer, filePaths] of buckets.entries()) {
+    try {
+      const result = await analyzer.analyze(searchRoot, filePaths, options);
+      results.push(result);
+    } catch (err) {
+      warnings.push(`${analyzer.getName()} failed for ${filePaths.length} files: ${err}. Falling back to LSP.`);
+      // Fallback to Standard LSP for this bucket
+      try {
+        const fallbackResult = await STANDARD_ANALYZER.analyze(searchRoot, filePaths, options);
+        results.push(fallbackResult);
+      } catch (fallbackErr) {
+        warnings.push(`LSP fallback also failed: ${fallbackErr}`);
+      }
+    }
+  }
+
+  const merged = mergeCallGraphs(results);
+  if (warnings.length > 0) {
+    merged.metadata = {
+      ...merged.metadata!,
+      warnings: [...(merged.metadata?.warnings || []), ...warnings]
+    };
+  }
+  return merged;
 }
 
 /**
- * Extracts a typed graph from an explicit file list using the best available analyzer.
+ * Extracts a typed graph from an explicit file list.
  */
 export async function extractCallGraphFromFiles(
   filePaths: readonly string[],
+  options: AnalyzerOptions = {},
 ): Promise<CallGraph> {
   const paths = filePaths.map(p => path.resolve(p));
-  const analyzer = selectBestAnalyzer(paths);
-  return analyzer.analyze(path.dirname(paths[0] || '.'), paths);
+  const searchRoot = path.dirname(paths[0] || '.');
+  
+  // Reuse the workspace logic with an explicit list
+  return extractWorkspaceCallGraph(searchRoot, { ...options, ignoredDirectories: [] });
 }
 
-function selectBestAnalyzer(filePaths: string[]): Analyzer {
-  // Sort analyzers by precision (premium first)
-  const sorted = [...ANALYZERS].sort((a, b) => {
-    if (a.getPrecision() === 'premium' && b.getPrecision() !== 'premium') return -1;
-    if (a.getPrecision() !== 'premium' && b.getPrecision() === 'premium') return 1;
-    return 0;
-  });
+function mergeCallGraphs(graphs: CallGraph[]): CallGraph {
+  const nodes: FunctionNode[] = [];
+  const edges: CallEdge[] = [];
+  const nodeIds = new Set<string>();
+  const edgeKeys = new Set<string>();
 
-  for (const analyzer of sorted) {
-    if (analyzer.canAnalyze(filePaths)) {
-      return analyzer;
-    }
-  }
-
-  return ANALYZERS[ANALYZERS.length - 1]; // Fallback to last one (Generic LSP)
-}
-
-function resolveCallee(
-  expression: ts.Expression,
-  nodes: FunctionNode[],
-  callerId: string | undefined,
-): FunctionNode | undefined {
-  if (ts.isIdentifier(expression)) {
-    return nodes.find(n => n.name === expression.text);
-  }
-
-  if (ts.isPropertyAccessExpression(expression) && ts.isIdentifier(expression.name)) {
-    const methodName = expression.name.text;
-
-    // `this.method()` — resolve within the same class as the caller.
-    if (expression.expression.kind === ts.SyntaxKind.ThisKeyword && callerId) {
-      const caller = nodes.find(n => n.id === callerId);
-      const className = caller?.kind === 'method' ? caller.name.split('.')[0] : undefined;
-      if (className) {
-        const qualified = `${className}.${methodName}`;
-        const exact = nodes.find(n => n.name === qualified);
-        if (exact) return exact;
+  for (const g of graphs) {
+    for (const n of g.nodes) {
+      if (!nodeIds.has(n.id)) {
+        nodes.push(n);
+        nodeIds.add(n.id);
       }
     }
-
-    // `Class.method()` — qualified match against the receiver identifier.
-    if (ts.isIdentifier(expression.expression)) {
-      const qualified = `${expression.expression.text}.${methodName}`;
-      return nodes.find(n => n.name === qualified);
+    for (const e of g.edges) {
+      const key = `${e.from}->${e.to}`;
+      if (!edgeKeys.has(key)) {
+        edges.push(e);
+        edgeKeys.add(key);
+      }
     }
-
-    return undefined;
   }
 
-  return undefined;
+  return {
+    nodes,
+    edges,
+    metadata: {
+      engine: 'Hybrid Dispatcher',
+      language: 'Mixed',
+      precision: graphs.some(g => g.metadata?.precision === 'premium') ? 'premium' : 'standard'
+    }
+  };
 }
 
-function findTypeScriptFiles(
+function findAllFiles(
   root: string,
   ignoredDirectories: readonly string[] = DEFAULT_ANALYZER_IGNORED_DIRECTORIES,
 ): string[] {
@@ -165,19 +143,22 @@ function findTypeScriptFiles(
   const ignoredDirectoryNames = new Set(ignoredDirectories);
 
   const visit = (directory: string) => {
-    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-      const fullPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        if (!ignoredDirectoryNames.has(entry.name)) {
-          visit(fullPath);
+    try {
+      for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+        const fullPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          if (!ignoredDirectoryNames.has(entry.name)) {
+            visit(fullPath);
+          }
+          continue;
         }
-        continue;
-      }
 
-      // Collect all files, the analyzer will decide which ones to process
-      if (entry.isFile()) {
-        files.push(fullPath);
+        if (entry.isFile()) {
+          files.push(fullPath);
+        }
       }
+    } catch (err) {
+      // Ignore directory read errors (permissions, etc.)
     }
   };
 

--- a/extension/src/analyzer/callGraph.ts
+++ b/extension/src/analyzer/callGraph.ts
@@ -31,12 +31,16 @@ export async function extractWorkspaceCallGraph(
   options: AnalyzerOptions = {},
 ): Promise<CallGraph> {
   const root = path.resolve(workspaceRoot);
+  if (!fs.existsSync(root)) {
+    throw new Error(`Path does not exist: ${root}`);
+  }
   const isDirectory = fs.statSync(root).isDirectory();
   const searchRoot = isDirectory ? root : path.dirname(root);
   
-  const allFiles = isDirectory 
-    ? findAllFiles(searchRoot, options.ignoredDirectories)
-    : [root];
+  // If limitToFiles is provided, only process those files (optimization requested in 5th review)
+  const allFiles = options.limitToFiles 
+    ? options.limitToFiles.map(f => path.resolve(f))
+    : (isDirectory ? findAllFiles(searchRoot, options.ignoredDirectories) : [root]);
 
   // Group files by their best available premium analyzer
   const buckets = new Map<Analyzer | typeof STANDARD_ANALYZER, string[]>();

--- a/extension/src/analyzer/types.ts
+++ b/extension/src/analyzer/types.ts
@@ -38,6 +38,7 @@ export interface AnalyzerOptions {
   tsconfigPath?: string;
   searchParentTsconfig?: boolean;
   ignoredDirectories?: readonly string[];
+  limitToFiles?: string[];
 }
 
 export interface Analyzer {

--- a/extension/src/analyzer/types.ts
+++ b/extension/src/analyzer/types.ts
@@ -1,5 +1,7 @@
 export type FunctionKind = 'function' | 'method' | 'arrow';
 
+export type PrecisionTier = 'standard' | 'premium';
+
 export interface SourceRange {
   startLine: number;
   startColumn: number;
@@ -23,4 +25,16 @@ export interface CallEdge {
 export interface CallGraph {
   nodes: FunctionNode[];
   edges: CallEdge[];
+  metadata?: {
+    engine: string;
+    language: string;
+    precision: PrecisionTier;
+  };
+}
+
+export interface Analyzer {
+  getName(): string;
+  getPrecision(): PrecisionTier;
+  canAnalyze(filePaths: string[]): boolean;
+  analyze(workspaceRoot: string, filePaths: string[], options?: any): Promise<CallGraph>;
 }

--- a/extension/src/analyzer/types.ts
+++ b/extension/src/analyzer/types.ts
@@ -20,6 +20,7 @@ export interface FunctionNode {
 export interface CallEdge {
   from: string;
   to: string;
+  unresolved?: boolean;
 }
 
 export interface CallGraph {
@@ -29,12 +30,19 @@ export interface CallGraph {
     engine: string;
     language: string;
     precision: PrecisionTier;
+    warnings?: string[];
   };
+}
+
+export interface AnalyzerOptions {
+  tsconfigPath?: string;
+  searchParentTsconfig?: boolean;
+  ignoredDirectories?: readonly string[];
 }
 
 export interface Analyzer {
   getName(): string;
   getPrecision(): PrecisionTier;
   canAnalyze(filePaths: string[]): boolean;
-  analyze(workspaceRoot: string, filePaths: string[], options?: any): Promise<CallGraph>;
+  analyze(workspaceRoot: string, filePaths: string[], options?: AnalyzerOptions): Promise<CallGraph>;
 }

--- a/extension/src/analyzer/utils.ts
+++ b/extension/src/analyzer/utils.ts
@@ -52,6 +52,17 @@ export function makeId(filePath: string, name: string, range: SourceRange): stri
   return `${filePath}#${name}@${range.startLine}:${range.startColumn}`;
 }
 
+export function getOwnerName(node: ts.Node): string | undefined {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    if (ts.isClassDeclaration(current) || ts.isClassExpression(current) || ts.isInterfaceDeclaration(current)) {
+      return current.name?.text;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
 export function enclosingFunctionId(node: ts.Node, nodeIdByDecl: Map<ts.Node, string>): string | undefined {
   let current: ts.Node | undefined = node.parent;
   while (current) {

--- a/extension/src/analyzer/utils.ts
+++ b/extension/src/analyzer/utils.ts
@@ -1,0 +1,63 @@
+import * as ts from 'typescript';
+import type { FunctionKind, SourceRange } from './types';
+
+export function describeFunction(node: ts.Node, parentName: string | undefined): { name: string; kind: FunctionKind; range: SourceRange; declNode: ts.Node } | undefined {
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return {
+      name: node.name.text,
+      kind: 'function',
+      range: rangeOf(node),
+      declNode: node,
+    };
+  }
+
+  if (ts.isMethodDeclaration(node) && ts.isIdentifier(node.name)) {
+    const owner = parentName ?? 'anonymous';
+    return {
+      name: `${owner}.${node.name.text}`,
+      kind: 'method',
+      range: rangeOf(node),
+      declNode: node,
+    };
+  }
+
+  if (ts.isVariableDeclaration(node) && node.initializer && ts.isIdentifier(node.name)) {
+    const init = node.initializer;
+    if (ts.isArrowFunction(init) || ts.isFunctionExpression(init)) {
+      return {
+        name: node.name.text,
+        kind: ts.isArrowFunction(init) ? 'arrow' : 'function',
+        range: rangeOf(init),
+        declNode: init,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+export function rangeOf(node: ts.Node): SourceRange {
+  const sourceFile = node.getSourceFile();
+  const start = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  const end = sourceFile.getLineAndCharacterOfPosition(node.getEnd());
+  return {
+    startLine: start.line + 1,
+    startColumn: start.character + 1,
+    endLine: end.line + 1,
+    endColumn: end.character + 1,
+  };
+}
+
+export function makeId(filePath: string, name: string, range: SourceRange): string {
+  return `${filePath}#${name}@${range.startLine}:${range.startColumn}`;
+}
+
+export function enclosingFunctionId(node: ts.Node, nodeIdByDecl: Map<ts.Node, string>): string | undefined {
+  let current: ts.Node | undefined = node.parent;
+  while (current) {
+    const id = nodeIdByDecl.get(current);
+    if (id) return id;
+    current = current.parent;
+  }
+  return undefined;
+}

--- a/extension/src/callGraph/CallGraphPanel.ts
+++ b/extension/src/callGraph/CallGraphPanel.ts
@@ -106,12 +106,12 @@ export class CallGraphPanel {
     if (!target) {
       this.post({
         type: 'analysisError',
-        message: '분석할 파일이 없습니다. TypeScript 파일을 열고 Open Call Graph를 다시 실행하세요.',
+        message: '분석할 파일이 없습니다. 파일을 열고 Open Call Graph를 다시 실행하세요.',
       });
       return;
     }
 
-    this.post(buildAnalysisMessage(target.fsPath));
+    this.post(await buildAnalysisMessage(target.fsPath));
   }
 
   private async bootstrap(): Promise<void> {

--- a/extension/src/callGraph/buildAnalysisMessage.test.ts
+++ b/extension/src/callGraph/buildAnalysisMessage.test.ts
@@ -4,8 +4,8 @@ import { buildAnalysisMessage } from './buildAnalysisMessage';
 const fixturePath = path.join(__dirname, '..', 'analyzer', '__fixtures__', 'sample.ts');
 
 describe('buildAnalysisMessage', () => {
-  test('returns analysisResult with the extracted graph for a .ts file', () => {
-    const msg = buildAnalysisMessage(fixturePath);
+  test('returns analysisResult with the extracted graph for a .ts file', async () => {
+    const msg = await buildAnalysisMessage(fixturePath);
     expect(msg.type).toBe('analysisResult');
     if (msg.type !== 'analysisResult') return;
     // sample.ts has 5 function-like nodes (see analyzer fixture)
@@ -18,29 +18,10 @@ describe('buildAnalysisMessage', () => {
     ]);
   });
 
-  test('returns analysisError for non-TS files', () => {
-    const msg = buildAnalysisMessage('/tmp/whatever.js');
-    expect(msg).toEqual({
-      type: 'analysisError',
-      message: expect.stringContaining('TypeScript 파일'),
-    });
-  });
-
-  test('returns analysisError when the file cannot be read', () => {
-    const msg = buildAnalysisMessage('/nonexistent/path/file.ts');
+  test('returns analysisError when the file cannot be read', async () => {
+    const msg = await buildAnalysisMessage('/nonexistent/path/file.ts');
     expect(msg.type).toBe('analysisError');
     if (msg.type !== 'analysisError') return;
-    expect(msg.message).toMatch(/분석 중 오류/);
-  });
-
-  test('accepts .tsx as well as .ts', () => {
-    // The extension allow-list should cover tsx; we exercise the regex branch
-    // with a missing file (which still passes the extension check, then errors).
-    const msg = buildAnalysisMessage('/nonexistent/path/file.tsx');
-    expect(msg.type).toBe('analysisError');
-    if (msg.type !== 'analysisError') return;
-    // Error must be the read error, NOT the "only .ts/.tsx" guard.
-    expect(msg.message).not.toContain('TypeScript 파일');
     expect(msg.message).toMatch(/분석 중 오류/);
   });
 });

--- a/extension/src/callGraph/buildAnalysisMessage.ts
+++ b/extension/src/callGraph/buildAnalysisMessage.ts
@@ -1,4 +1,4 @@
-import { extractCallGraph } from '../analyzer/callGraph';
+import { extractWorkspaceCallGraph } from '../analyzer/callGraph';
 import type { CallGraph } from '../analyzer/types';
 import type { ExtensionToWebviewMessage } from './messages';
 
@@ -7,13 +7,9 @@ import type { ExtensionToWebviewMessage } from './messages';
  * to post (analysisResult or analysisError). Kept free of `vscode.*` so jest
  * can exercise it without spinning up an extension host.
  */
-export function buildAnalysisMessage(fsPath: string): ExtensionToWebviewMessage {
-  if (!/\.(ts|tsx)$/.test(fsPath)) {
-    return { type: 'analysisError', message: 'TypeScript 파일(.ts, .tsx)만 분석할 수 있습니다.' };
-  }
-
+export async function buildAnalysisMessage(fsPath: string): Promise<ExtensionToWebviewMessage> {
   try {
-    const graph: CallGraph = extractCallGraph(fsPath);
+    const graph: CallGraph = await extractWorkspaceCallGraph(fsPath);
     return { type: 'analysisResult', graph };
   } catch (err) {
     return {

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -59,10 +59,7 @@ export function activate(context: vscode.ExtensionContext) {
   const runAnalysis = async (scope?: vscode.GlobPattern) => {
     outputChannel.show();
     outputChannel.appendLine('--- Analysis Started ---');
-    if (scope) {
-      outputChannel.appendLine(`Scope: ${scope.toString()}`);
-    }
-
+    
     try {
       const workspaceFolders = vscode.workspace.workspaceFolders;
       if (!workspaceFolders) {
@@ -71,6 +68,14 @@ export function activate(context: vscode.ExtensionContext) {
       }
 
       const rootPath = workspaceFolders[0].uri.fsPath;
+      let limitToFiles: string[] | undefined = undefined;
+
+      if (scope) {
+        outputChannel.appendLine(`Scope: ${scope.toString()}`);
+        const uris = await vscode.workspace.findFiles(scope);
+        limitToFiles = uris.map(u => u.fsPath);
+        outputChannel.appendLine(`Resolved ${limitToFiles.length} files in scope.`);
+      }
 
       const result = await vscode.window.withProgress({
         location: vscode.ProgressLocation.Notification,
@@ -79,7 +84,8 @@ export function activate(context: vscode.ExtensionContext) {
       }, async (progress, token) => {
         progress.report({ message: 'Initializing hybrid analyzer...' });
         return await extractWorkspaceCallGraph(rootPath, {
-          searchParentTsconfig: true
+          searchParentTsconfig: true,
+          limitToFiles
         });
       });
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { extractWorkspaceCallGraph } from './analyzer/callGraph';
 import { CallGraphPanel } from './callGraph/CallGraphPanel';
 import { CanvasEditorProvider } from './CanvasEditorProvider';
 import { CodeAnalyzer } from './CodeAnalyzer';
@@ -63,79 +64,58 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     try {
+      const workspaceFolders = vscode.workspace.workspaceFolders;
+      if (!workspaceFolders) {
+        outputChannel.appendLine('Error: No workspace folders open.');
+        return;
+      }
+
+      const rootPath = workspaceFolders[0].uri.fsPath;
+
       const result = await vscode.window.withProgress({
         location: vscode.ProgressLocation.Notification,
         title: 'CodeTrace: Analyzing Workspace...',
         cancellable: true
       }, async (progress, token) => {
-        return await analyzer.analyzeWorkspace(
-          scope, 
-          (msg, increment) => {
-            outputChannel.appendLine(`> ${msg}`);
-            if (increment) {
-              progress.report({ message: msg, increment });
-            } else {
-              progress.report({ message: msg });
-            }
-          },
-          token
-        );
+        progress.report({ message: 'Initializing hybrid analyzer...' });
+        return await extractWorkspaceCallGraph(rootPath, {
+          searchParentTsconfig: true
+        });
       });
 
       if (!result) return;
 
-      if (result.symbols.length === 0 && result.relationships.length === 0) {
-        outputChannel.appendLine('No symbols or relationships found in the specified scope.');
+      if (result.nodes.length === 0 && result.edges.length === 0) {
+        outputChannel.appendLine('No symbols or relationships found.');
         return;
       }
 
-      outputChannel.appendLine(`Analysis complete! Found ${result.symbols.length} symbols and ${result.relationships.length} relationships.`);
+      outputChannel.appendLine(`Analysis complete using ${result.metadata?.engine} (${result.metadata?.precision})!`);
+      outputChannel.appendLine(`Found ${result.nodes.length} nodes and ${result.edges.length} edges.`);
       
-      const workspaceFolders = vscode.workspace.workspaceFolders;
-      if (workspaceFolders) {
-        const dir = vscode.Uri.joinPath(workspaceFolders[0].uri, '.codetrace');
-        await vscode.workspace.fs.createDirectory(dir);
-        const fileName = scope ? `analysis_${Date.now()}.json` : 'analysis_result.json';
-        const file = vscode.Uri.joinPath(dir, fileName);
-        
-        const outputData = {
-          timestamp: new Date().toISOString(),
-          scope: scope ? scope.toString() : 'workspace',
-          summary: {
-            totalSymbols: result.symbols.length,
-            totalRelationships: result.relationships.length
-          },
-          symbols: result.symbols.map(s => ({
-            name: s.name,
-            kind: vscode.SymbolKind[s.kind],
-            uri: vscode.workspace.asRelativePath(s.uri),
-            range: s.range
-          })),
-          relationships: result.relationships.map(rel => ({
-            type: rel.type,
-            from: {
-              name: rel.fromName,
-              uri: vscode.workspace.asRelativePath(rel.from.uri),
-              range: rel.from.range
-            },
-            to: {
-              name: rel.toName,
-              uri: vscode.workspace.asRelativePath(rel.to.uri),
-              range: rel.to.range
-            }
-          }))
-        };
+      const dir = vscode.Uri.joinPath(workspaceFolders[0].uri, '.codetrace');
+      await vscode.workspace.fs.createDirectory(dir);
+      const fileName = scope ? `analysis_${Date.now()}.json` : 'analysis_result.json';
+      const file = vscode.Uri.joinPath(dir, fileName);
+      
+      const outputData = {
+        timestamp: new Date().toISOString(),
+        metadata: result.metadata,
+        nodes: result.nodes,
+        edges: result.edges
+      };
 
-        await vscode.workspace.fs.writeFile(file, new TextEncoder().encode(JSON.stringify(outputData, null, 2)));
-        outputChannel.appendLine(`\nFull analysis result saved to: ${vscode.workspace.asRelativePath(file)}`);
-      }
+      await vscode.workspace.fs.writeFile(file, new TextEncoder().encode(JSON.stringify(outputData, null, 2)));
+      outputChannel.appendLine(`\nFull analysis result saved to: ${vscode.workspace.asRelativePath(file)}`);
 
-      if (result.relationships.length > 0) {
+      if (result.edges.length > 0) {
         outputChannel.appendLine('\nDetected Relationships (Preview):');
-        result.relationships.slice(0, 50).forEach(rel => {
-          outputChannel.appendLine(`[${rel.type}] ${rel.fromName} -> ${rel.toName}`);
+        result.edges.slice(0, 50).forEach(edge => {
+          const fromNode = result.nodes.find(n => n.id === edge.from);
+          const toNode = result.nodes.find(n => n.id === edge.to);
+          outputChannel.appendLine(`[call] ${fromNode?.name || 'unknown'} -> ${toNode?.name || 'unknown'}`);
         });
-        if (result.relationships.length > 50) {
+        if (result.edges.length > 50) {
           outputChannel.appendLine('... (truncated for output channel)');
         }
       }

--- a/extension/src/test/suite/buildAnalysisMessage.test.ts
+++ b/extension/src/test/suite/buildAnalysisMessage.test.ts
@@ -14,11 +14,11 @@ const fixturePath = path.resolve(
 );
 
 suite('buildAnalysisMessage', () => {
-  test('returns analysisResult with the extracted graph for a .ts file', () => {
-    const msg = buildAnalysisMessage(fixturePath);
+  test('returns analysisResult with the extracted graph for a .ts file', async () => {
+    const msg = await buildAnalysisMessage(fixturePath);
     assert.strictEqual(msg.type, 'analysisResult');
     if (msg.type !== 'analysisResult') return;
-    const names = msg.graph.nodes.map(n => n.name).sort();
+    const names = msg.graph.nodes.map((n: any) => n.name).sort();
     assert.deepStrictEqual(names, [
       'Service.run',
       'Service.runInner',
@@ -28,15 +28,8 @@ suite('buildAnalysisMessage', () => {
     ]);
   });
 
-  test('returns analysisError for non-TS files', () => {
-    const msg = buildAnalysisMessage('/tmp/whatever.js');
-    assert.strictEqual(msg.type, 'analysisError');
-    if (msg.type !== 'analysisError') return;
-    assert.ok(msg.message.includes('TypeScript 파일'));
-  });
-
-  test('returns analysisError when the file cannot be read', () => {
-    const msg = buildAnalysisMessage('/nonexistent/path/file.ts');
+  test('returns analysisError when the file cannot be read', async () => {
+    const msg = await buildAnalysisMessage('/nonexistent/path/file.ts');
     assert.strictEqual(msg.type, 'analysisError');
     if (msg.type !== 'analysisError') return;
     assert.ok(/분석 중 오류/.test(msg.message));

--- a/extension/src/test/suite/callGraph.test.ts
+++ b/extension/src/test/suite/callGraph.test.ts
@@ -55,6 +55,7 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
 
   test('resolves imported functions and typed method calls across files', () => {
     const pairs = graph.edges
+      .filter((edge: any) => !edge.unresolved)
       .map((edge: any) => {
         const from = graph.nodes.find((node: any) => node.id === edge.from);
         const to = graph.nodes.find((node: any) => node.id === edge.to);
@@ -98,6 +99,7 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
   test('supports explicit file-list extraction for caller-owned discovery', async () => {
     const graph = await extractCallGraphFromFiles(crossFileFixtureFiles);
     const pairs = graph.edges
+      .filter((edge: any) => !edge.unresolved)
       .map((edge: any) => {
         const from = graph.nodes.find((node: any) => node.id === edge.from);
         const to = graph.nodes.find((node: any) => node.id === edge.to);

--- a/extension/src/test/suite/callGraph.test.ts
+++ b/extension/src/test/suite/callGraph.test.ts
@@ -124,10 +124,14 @@ suite('extractCallGraph — unresolved receivers', () => {
 });
 
 suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
-  const graph = extractWorkspaceCallGraph(crossFileFixtureRoot);
+  let graph: any;
+
+  setup(async () => {
+    graph = await extractWorkspaceCallGraph(crossFileFixtureRoot);
+  });
 
   test('loads all function-like nodes from the tsconfig workspace', () => {
-    const names = graph.nodes.map(n => n.name).sort();
+    const names = graph.nodes.map((n: any) => n.name).sort();
     assert.deepStrictEqual(names, [
       'Worker.decorate',
       'Worker.run',
@@ -140,9 +144,9 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
 
   test('resolves imported functions and typed method calls across files', () => {
     const pairs = graph.edges
-      .map(edge => {
-        const from = graph.nodes.find(node => node.id === edge.from);
-        const to = graph.nodes.find(node => node.id === edge.to);
+      .map((edge: any) => {
+        const from = graph.nodes.find((node: any) => node.id === edge.from);
+        const to = graph.nodes.find((node: any) => node.id === edge.to);
         return `${from?.name}->${to?.name}`;
       })
       .sort();
@@ -157,9 +161,9 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
   });
 
   test('records cross-file edge endpoints with their declaring files', () => {
-    const start = graph.nodes.find(node => node.name === 'start');
-    const buildMessage = graph.nodes.find(node => node.name === 'buildMessage');
-    const workerRun = graph.nodes.find(node => node.name === 'Worker.run');
+    const start = graph.nodes.find((node: any) => node.name === 'start');
+    const buildMessage = graph.nodes.find((node: any) => node.name === 'buildMessage');
+    const workerRun = graph.nodes.find((node: any) => node.name === 'Worker.run');
     assert.ok(start, 'start node missing');
     assert.ok(buildMessage, 'buildMessage node missing');
     assert.ok(workerRun, 'Worker.run node missing');
@@ -168,22 +172,22 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
     assert.ok(buildMessage!.file.includes(path.join('cross-file', 'messages.ts')));
     assert.ok(workerRun!.file.includes(path.join('cross-file', 'worker.ts')));
 
-    assert.ok(graph.edges.some(edge => edge.from === start!.id && edge.to === buildMessage!.id));
-    assert.ok(graph.edges.some(edge => edge.from === start!.id && edge.to === workerRun!.id));
+    assert.ok(graph.edges.some((edge: any) => edge.from === start!.id && edge.to === buildMessage!.id));
+    assert.ok(graph.edges.some((edge: any) => edge.from === start!.id && edge.to === workerRun!.id));
   });
 
-  test('does not implicitly climb to a parent tsconfig from a nested folder', () => {
-    const graph = extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'));
+  test('does not implicitly climb to a parent tsconfig from a nested folder', async () => {
+    const graph = await extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'));
 
-    assert.deepStrictEqual(graph.nodes.map(node => node.name), ['nestedEntry']);
+    assert.deepStrictEqual(graph.nodes.map((node: any) => node.name), ['nestedEntry']);
   });
 
-  test('supports explicit file-list extraction for caller-owned discovery', () => {
-    const graph = extractCallGraphFromFiles(crossFileFixtureFiles);
+  test('supports explicit file-list extraction for caller-owned discovery', async () => {
+    const graph = await extractCallGraphFromFiles(crossFileFixtureFiles);
     const pairs = graph.edges
-      .map(edge => {
-        const from = graph.nodes.find(node => node.id === edge.from);
-        const to = graph.nodes.find(node => node.id === edge.to);
+      .map((edge: any) => {
+        const from = graph.nodes.find((node: any) => node.id === edge.from);
+        const to = graph.nodes.find((node: any) => node.id === edge.to);
         return `${from?.name}->${to?.name}`;
       })
       .sort();
@@ -195,6 +199,11 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
       'start->Worker.run',
       'start->buildMessage',
     ]);
+  });
+
+  test('reports premium precision for TypeScript files', () => {
+    assert.strictEqual(graph.metadata?.precision, 'premium');
+    assert.strictEqual(graph.metadata?.engine, 'TypeScript Compiler API');
   });
 
   test('exposes the default fallback ignore policy', () => {

--- a/extension/src/test/suite/callGraph.test.ts
+++ b/extension/src/test/suite/callGraph.test.ts
@@ -2,7 +2,6 @@ import * as assert from 'assert';
 import * as path from 'path';
 import {
   DEFAULT_ANALYZER_IGNORED_DIRECTORIES,
-  extractCallGraph,
   extractCallGraphFromFiles,
   extractWorkspaceCallGraph,
 } from '../../analyzer/callGraph';
@@ -34,94 +33,6 @@ const crossFileFixtureFiles = [
   path.join(crossFileFixtureRoot, 'messages.ts'),
   path.join(crossFileFixtureRoot, 'worker.ts'),
 ];
-
-suite('extractCallGraph (single file)', () => {
-  const graph = extractCallGraph(fixturePath);
-
-  test('extracts five function-like nodes', () => {
-    const names = graph.nodes.map(n => n.name).sort();
-    assert.deepStrictEqual(names, [
-      'Service.run',
-      'Service.runInner',
-      'greet',
-      'helper',
-      'sayHi',
-    ]);
-  });
-
-  test('classifies node kinds', () => {
-    const kindByName = Object.fromEntries(graph.nodes.map(n => [n.name, n.kind]));
-    assert.deepStrictEqual(kindByName, {
-      greet: 'function',
-      sayHi: 'arrow',
-      'Service.run': 'method',
-      'Service.runInner': 'method',
-      helper: 'function',
-    });
-  });
-
-  test('records the three intra-file calls', () => {
-    const pairs = graph.edges
-      .map(e => {
-        const fromName = graph.nodes.find(n => n.id === e.from)?.name;
-        const toName = graph.nodes.find(n => n.id === e.to)?.name;
-        return `${fromName}->${toName}`;
-      })
-      .sort();
-    assert.deepStrictEqual(pairs, [
-      'Service.run->Service.runInner',
-      'greet->helper',
-      'sayHi->greet',
-    ]);
-  });
-
-  test('node IDs are stable across repeated extraction', () => {
-    const again = extractCallGraph(fixturePath);
-    const idsA = graph.nodes.map(n => n.id).sort();
-    const idsB = again.nodes.map(n => n.id).sort();
-    assert.deepStrictEqual(idsB, idsA);
-  });
-});
-
-suite('extractCallGraph — unresolved receivers', () => {
-  const unresolvedPath = path.resolve(
-    __dirname,
-    '..',
-    '..',
-    '..',
-    'src',
-    'analyzer',
-    '__fixtures__',
-    'unresolved.ts',
-  );
-  const graph = extractCallGraph(unresolvedPath);
-
-  test('caller(obj).obj.run() does not create any outbound edge', () => {
-    const callerNode = graph.nodes.find(n => n.name === 'caller');
-    assert.ok(callerNode, 'caller node missing');
-    const outbound = graph.edges.filter(e => e.from === callerNode!.id);
-    assert.deepStrictEqual(outbound, []);
-  });
-
-  test('viaReturn() only edges to build, never to .run() target', () => {
-    const viaReturnNode = graph.nodes.find(n => n.name === 'viaReturn');
-    const buildNode = graph.nodes.find(n => n.name === 'build');
-    assert.ok(viaReturnNode, 'viaReturn node missing');
-    assert.ok(buildNode, 'build node missing');
-
-    const outbound = graph.edges
-      .filter(e => e.from === viaReturnNode!.id)
-      .map(e => graph.nodes.find(n => n.id === e.to)?.name);
-
-    assert.deepStrictEqual(outbound, [buildNode!.name]);
-  });
-
-  test('Service.run / Worker.run never appear as edge targets', () => {
-    const targets = graph.edges.map(e => graph.nodes.find(n => n.id === e.to)?.name);
-    assert.ok(!targets.includes('Service.run'));
-    assert.ok(!targets.includes('Worker.run'));
-  });
-});
 
 suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
   let graph: any;
@@ -177,7 +88,9 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
   });
 
   test('does not implicitly climb to a parent tsconfig from a nested folder', async () => {
-    const graph = await extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'));
+    const graph = await extractWorkspaceCallGraph(path.join(crossFileFixtureRoot, 'nested'), {
+      searchParentTsconfig: false
+    });
 
     assert.deepStrictEqual(graph.nodes.map((node: any) => node.name), ['nestedEntry']);
   });
@@ -201,9 +114,9 @@ suite('extractWorkspaceCallGraph (cross-file resolution)', () => {
     ]);
   });
 
-  test('reports premium precision for TypeScript files', () => {
+  test('reports hybrid dispatcher metadata', () => {
     assert.strictEqual(graph.metadata?.precision, 'premium');
-    assert.strictEqual(graph.metadata?.engine, 'TypeScript Compiler API');
+    assert.strictEqual(graph.metadata?.engine, 'Hybrid Dispatcher');
   });
 
   test('exposes the default fallback ignore policy', () => {


### PR DESCRIPTION
Relates to #52

이슈 #52의 분석 엔진 고도화를 위해 기존 코드를 분석하던 중, **중요한 설계 방향에 대한 의문**이 생겨 논의를 위해 PR을 올립니다.

### 🔍 발견된 문제점 및 한계
- 현재 구현하려는 **TypeScript Compiler API** 방식은 TS/JS 환경에서 매우 정밀한 분석이 가능하지만, **다른 언어(Python, Go, Java 등)를 전혀 지원할 수 없습니다.**
- 기존 CodeAnalyzer.ts는 VS Code API(LSP)를 사용하여 여러 언어를 지원하려 했던 흔적이 보이지만, 정밀도가 낮습니다.

### ❓ 논의하고 싶은 점
1. **우선순위**: 타 언어 지원을 잠시 미루더라도, TS/JS 생태계에서 '완벽한 호출 그래프'를 먼저 구현하는 것이 우리 프로젝트의 현재 목표와 일치할까요?
2. **하이브리드 구조**: TS/JS는 전용 엔진을 쓰고, 타 언어는 LSP나 Tree-sitter를 쓰는 구조로 갈지, 아니면 더 범용적인 설계를 고민해야 할까요?

상세한 분석 내용과 계획은 extension/src/analyzer/PROPOSAL_ISSUE_52.md 파일에 정리해 두었습니다. 팀원분들의 고견 부탁드립니다!