### PR TITLE
fix(ci): recognize all GitHub closing keywords in project-automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -17,7 +17,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          ISSUE=$(echo "$PR_BODY" | grep -oiP '(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#\K[0-9]+' | head -1)
+          ISSUE=$(printf '%s' "$PR_BODY" | grep -oiP '(?:^|\s)(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+#\K[0-9]+' | head -1)
           echo "number=${ISSUE}" >> $GITHUB_OUTPUT
           echo "Linked issue: ${ISSUE}"
 

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -17,7 +17,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          ISSUE=$(echo "$PR_BODY" | grep -oP '(?i)closes?\s+#\K[0-9]+' | head -1)
+          ISSUE=$(echo "$PR_BODY" | grep -oiP '(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#\K[0-9]+' | head -1)
           echo "number=${ISSUE}" >> $GITHUB_OUTPUT
           echo "Linked issue: ${ISSUE}"
 


### PR DESCRIPTION
## Summary

- 워크플로의 정규식을 `(?:^|\s)(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?):?\s+#\K[0-9]+`로 확장
- GitHub이 인식하는 9개 키워드(close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved) 전부 매칭
- 단어 경계와 optional colon (`Fixes: #N`)까지 반영, false positive 차단

## Changes

- `.github/workflows/project-automation.yml`: regex 패턴 확장 + `echo` → `printf '%s'`로 multi-line 본문 안전 처리

## Related Issue
Closes #77

## 배경

PR #74가 본문에 `Resolves #68`을 명시했지만 워크플로가 issue를 못 찾아 project status 자동 이동(In progress → In review)이 실패했음. 워크플로 로그 확인 결과 `Linked issue: ` (빈값).

## Test plan

- [x] 21개 perl PCRE 케이스 통과 (positive 15 + negative 5 + edge 1)
  - Positive: `Close/Closes/Closed`, `Fix/Fixes/Fixed`, `Resolve/Resolves/Resolved`, `Fixes: #N` colon, leading text, newline, multiline body
  - Negative: `unresolved #N`, `prefixes #N`, `fixes#N` (no-space, GitHub 공식 미지원), `afix #N`, `preclose #N`
  - Edge: 첫 매칭 우선
- [ ] 머지 후 다음 PR이 `Resolves #N`/`Fixes #N`/`Closes #N`/`Fixes: #N` 어떤 형태든 In review로 자동 이동되는지 확인