### PR TITLE
feat(frontend): 자동 마인드맵을 Excalidraw element로 렌더 + 잠금/위치 보존 (#69)

### DIFF
--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -3,6 +3,8 @@ import * as vscode from 'vscode';
 export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
   static readonly viewType = 'codetrace.canvasEditor';
 
+  private static readonly activePanels = new Set<vscode.WebviewPanel>();
+
   static register(context: vscode.ExtensionContext): vscode.Disposable {
     return vscode.window.registerCustomEditorProvider(
       CanvasEditorProvider.viewType,
@@ -12,6 +14,12 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
         supportsMultipleEditorsPerDocument: false,
       }
     );
+  }
+
+  static broadcast(message: unknown): void {
+    for (const panel of CanvasEditorProvider.activePanels) {
+      panel.webview.postMessage(message);
+    }
   }
 
   constructor(private readonly context: vscode.ExtensionContext) {}
@@ -61,7 +69,10 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       }
     });
 
+    CanvasEditorProvider.activePanels.add(webviewPanel);
+
     webviewPanel.onDidDispose(() => {
+      CanvasEditorProvider.activePanels.delete(webviewPanel);
       changeSubscription.dispose();
       saveSubscription.dispose();
     });
@@ -120,10 +131,12 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     window.__codetrace_initialContent = ${this._scriptString(initialContent)};
 
     window.addEventListener('message', event => {
-      const { type, content } = event.data ?? {};
-      if (type === 'update' && typeof content === 'string') {
-        window.__codetrace_initialContent = content;
-        if (window.__codetrace_onUpdate) window.__codetrace_onUpdate(content);
+      const data = event.data ?? {};
+      if (data.type === 'update' && typeof data.content === 'string') {
+        window.__codetrace_initialContent = data.content;
+        if (window.__codetrace_onUpdate) window.__codetrace_onUpdate(data.content);
+      } else if (data.type === 'analysis' && data.payload) {
+        if (window.__codetrace_onAnalysis) window.__codetrace_onAnalysis(data.payload);
       }
     });
 

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -87,11 +87,11 @@ export function activate(context: vscode.ExtensionContext) {
       
       const dir = vscode.Uri.joinPath(workspaceFolders[0].uri, '.codetrace');
       await vscode.workspace.fs.createDirectory(dir);
-      const fileName = scope ? `analysis_${Date.now()}.json` : 'analysis_result.json';
-      const file = vscode.Uri.joinPath(dir, fileName);
-      
+      const file = vscode.Uri.joinPath(dir, 'analysis_cache.json');
+
       const outputData = {
         timestamp: new Date().toISOString(),
+        scope: scope ? scope.toString() : null,
         metadata: result.metadata,
         nodes: result.nodes,
         edges: result.edges
@@ -99,6 +99,11 @@ export function activate(context: vscode.ExtensionContext) {
 
       await vscode.workspace.fs.writeFile(file, new TextEncoder().encode(JSON.stringify(outputData, null, 2)));
       outputChannel.appendLine(`\nFull analysis result saved to: ${vscode.workspace.asRelativePath(file)}`);
+
+      CanvasEditorProvider.broadcast({
+        type: 'analysis',
+        payload: { nodes: result.nodes, edges: result.edges },
+      });
 
       if (result.edges.length > 0) {
         outputChannel.appendLine('\nDetected Relationships (Preview):');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@excalidraw/excalidraw": "^0.18.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { Excalidraw, CaptureUpdateAction } from '@excalidraw/excalidraw';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ComponentProps } from 'react';
 import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
 import type {
@@ -17,9 +17,17 @@ import {
 import { serializeCanvasDocument, type ExcalidrawElementStub } from './types/CanvasDocument';
 import type { CodeCard } from './types/CodeCard';
 import {
+  convertGraphToElements,
+  extractPositions,
+  partitionElements,
+  setAutoElementsLocked,
+} from './graph/converter';
+import type { CallGraphPayload } from './graph/types';
+import {
   getInitialDocumentContent,
   saveDocumentContent,
   saveDocumentFile,
+  subscribeAnalysisUpdates,
   subscribeDocumentUpdates,
 } from './vscodeBridge';
 
@@ -35,10 +43,10 @@ export default function App() {
   const initialData = useMemo(() => toExcalidrawInitialData(initialDocument), [initialDocument]);
 
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
-  // §C4(폐기) 이후에도 .codetrace 파일의 cards 필드는 round-trip 보존한다 (#69에서 graphNode/reviewSticky 모델로 마이그레이션 예정).
   const cardsRef = useRef<CodeCard[]>([]);
   const latestContentRef = useRef<string>(initialContent);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const [autoLocked, setAutoLocked] = useState(true);
 
   useEffect(() => {
     cardsRef.current = initialDocument.cards;
@@ -82,6 +90,49 @@ export default function App() {
 
   useEffect(() => subscribeDocumentUpdates(applyDocumentContent), [applyDocumentContent]);
 
+  const applyAnalysis = useCallback(
+    (payload: CallGraphPayload) => {
+      const api = apiRef.current;
+      if (!api) return;
+
+      const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+      const { user } = partitionElements(current);
+      const existingPositions = extractPositions(current);
+
+      const { elements: autoElements } = convertGraphToElements(
+        payload.nodes,
+        payload.edges,
+        existingPositions,
+        { locked: autoLocked },
+      );
+
+      const next = [...autoElements, ...user];
+      api.updateScene({
+        elements: next as unknown as ExcalidrawElement[],
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      });
+    },
+    [autoLocked],
+  );
+
+  useEffect(() => subscribeAnalysisUpdates(applyAnalysis), [applyAnalysis]);
+
+  const toggleAutoLock = useCallback(() => {
+    setAutoLocked((prev) => {
+      const next = !prev;
+      const api = apiRef.current;
+      if (api) {
+        const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+        const updated = setAutoElementsLocked(current, next);
+        api.updateScene({
+          elements: updated as unknown as ExcalidrawElement[],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      }
+      return next;
+    });
+  }, []);
+
   const handleExcalidrawAPI = useCallback((api: ExcalidrawImperativeAPI) => {
     apiRef.current = api;
   }, []);
@@ -105,7 +156,26 @@ export default function App() {
   );
 
   return (
-    <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
+    <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
+      <button
+        type="button"
+        onClick={toggleAutoLock}
+        style={{
+          position: 'absolute',
+          top: 12,
+          right: 12,
+          zIndex: 10,
+          padding: '6px 10px',
+          fontSize: 12,
+          background: autoLocked ? '#eef2ff' : '#fef3c7',
+          border: '1px solid #4f46e5',
+          borderRadius: 6,
+          cursor: 'pointer',
+        }}
+        title="자동 생성 노드의 잠금을 토글합니다"
+      >
+        {autoLocked ? '자동 노드 잠금' : '자동 노드 해제'}
+      </button>
       <Excalidraw
         excalidrawAPI={handleExcalidrawAPI}
         initialData={initialData as unknown as ExcalidrawInitialDataState}

--- a/frontend/src/graph/converter.test.ts
+++ b/frontend/src/graph/converter.test.ts
@@ -1,0 +1,201 @@
+jest.mock('@excalidraw/excalidraw', () => ({
+  convertToExcalidrawElements: (skeletons: Array<Record<string, unknown>>) => {
+    // Simulate Excalidraw's behavior: container `label` becomes a separate text element
+    // with a containerId pointing back to the container.
+    const out: Array<Record<string, unknown>> = [];
+    for (const skel of skeletons) {
+      if (skel.type === 'rectangle' && skel.label) {
+        const { label, ...rest } = skel as {
+          label: { text: string; fontSize?: number; strokeColor?: string };
+          id: string;
+          x: number;
+          y: number;
+          locked?: boolean;
+        };
+        out.push({ ...rest, boundElements: [{ id: `${rest.id}-label`, type: 'text' }] });
+        out.push({
+          id: `${rest.id}-label`,
+          type: 'text',
+          x: rest.x,
+          y: rest.y,
+          width: 100,
+          height: 20,
+          text: label.text,
+          containerId: rest.id,
+          fontSize: label.fontSize,
+          strokeColor: label.strokeColor,
+          locked: rest.locked ?? false,
+        });
+      } else if (skel.type === 'arrow') {
+        const start = (skel as { start?: { id: string } }).start;
+        const end = (skel as { end?: { id: string } }).end;
+        out.push({
+          ...skel,
+          startBinding: start ? { elementId: start.id, focus: 0, gap: 0 } : undefined,
+          endBinding: end ? { elementId: end.id, focus: 0, gap: 0 } : undefined,
+        });
+      } else {
+        out.push(skel);
+      }
+    }
+    return out;
+  },
+}));
+
+import {
+  convertGraphToElements,
+  extractPositions,
+  isAutoElement,
+  partitionElements,
+  setAutoElementsLocked,
+} from './converter';
+import type { GraphEdge, GraphNode } from './types';
+import { GRAPH_ELEMENT_KIND_EDGE, GRAPH_ELEMENT_KIND_NODE } from './types';
+import type { ExcalidrawElementStub } from '../types/CanvasDocument';
+
+if (typeof (globalThis as { structuredClone?: unknown }).structuredClone !== 'function') {
+  (globalThis as { structuredClone: typeof structuredClone }).structuredClone = (value: unknown) =>
+    JSON.parse(JSON.stringify(value));
+}
+
+const sampleNodes: GraphNode[] = [
+  {
+    id: 'a',
+    name: 'foo',
+    kind: 'function',
+    file: 'src/a.ts',
+    range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 },
+  },
+  {
+    id: 'b',
+    name: 'bar',
+    kind: 'function',
+    file: 'src/b.ts',
+    range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 },
+  },
+];
+
+const sampleEdges: GraphEdge[] = [{ from: 'a', to: 'b' }];
+
+describe('convertGraphToElements', () => {
+  it('produces a rectangle, label, and arrow per node/edge', () => {
+    const { elements } = convertGraphToElements(sampleNodes, sampleEdges);
+    const rects = elements.filter((e) => e.type === 'rectangle');
+    const arrows = elements.filter((e) => e.type === 'arrow');
+    const labels = elements.filter((e) => e.type === 'text');
+
+    expect(rects).toHaveLength(2);
+    expect(arrows).toHaveLength(1);
+    expect(labels).toHaveLength(2);
+  });
+
+  it('marks generated elements with customData.kind and source=auto', () => {
+    const { elements } = convertGraphToElements(sampleNodes, sampleEdges);
+    for (const element of elements) {
+      const data = element.customData as { kind: string; source?: string };
+      expect([GRAPH_ELEMENT_KIND_NODE, GRAPH_ELEMENT_KIND_EDGE]).toContain(data.kind);
+      expect(data.source).toBe('auto');
+    }
+  });
+
+  it('locks auto elements by default', () => {
+    const { elements } = convertGraphToElements(sampleNodes, sampleEdges);
+    expect(elements.every((e) => e.locked === true)).toBe(true);
+  });
+
+  it('respects locked: false option', () => {
+    const { elements } = convertGraphToElements(sampleNodes, sampleEdges, new Map(), { locked: false });
+    expect(elements.every((e) => e.locked === false)).toBe(true);
+  });
+
+  it('preserves existing positions and only lays out new nodes', () => {
+    const existing = new Map([['a', { x: 1000, y: 2000 }]]);
+    const { positions } = convertGraphToElements(sampleNodes, sampleEdges, existing);
+    expect(positions.get('a')).toEqual({ x: 1000, y: 2000 });
+    expect(positions.get('b')).toBeDefined();
+    expect(positions.get('b')?.x).not.toBe(1000);
+  });
+
+  it('drops positions for nodes that no longer exist', () => {
+    const existing = new Map([
+      ['a', { x: 1000, y: 2000 }],
+      ['ghost', { x: 5, y: 5 }],
+    ]);
+    const { positions } = convertGraphToElements(sampleNodes, sampleEdges, existing);
+    expect(positions.has('ghost')).toBe(false);
+  });
+
+  it('binds arrow start/end to the auto-node element ids', () => {
+    const { elements } = convertGraphToElements(sampleNodes, sampleEdges);
+    const arrow = elements.find((e) => e.type === 'arrow');
+    expect(arrow).toBeDefined();
+    const startBinding = arrow?.startBinding as { elementId: string };
+    const endBinding = arrow?.endBinding as { elementId: string };
+    expect(startBinding?.elementId).toBe('auto-node-a');
+    expect(endBinding?.elementId).toBe('auto-node-b');
+  });
+
+  it('skips edges whose endpoints have no position', () => {
+    const orphanEdges: GraphEdge[] = [{ from: 'a', to: 'missing' }];
+    const { elements } = convertGraphToElements(sampleNodes, orphanEdges);
+    expect(elements.find((e) => e.type === 'arrow')).toBeUndefined();
+  });
+});
+
+describe('extractPositions', () => {
+  it('reads positions from auto graphNode rectangles', () => {
+    const elements: ExcalidrawElementStub[] = [
+      {
+        id: 'auto-node-a',
+        type: 'rectangle',
+        x: 10,
+        y: 20,
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId: 'a', source: 'auto' },
+      },
+      {
+        id: 'user-shape',
+        type: 'rectangle',
+        x: 99,
+        y: 99,
+      },
+    ];
+    const positions = extractPositions(elements);
+    expect(positions.get('a')).toEqual({ x: 10, y: 20 });
+    expect(positions.size).toBe(1);
+  });
+});
+
+describe('partitionElements', () => {
+  it('separates auto elements from user elements', () => {
+    const elements: ExcalidrawElementStub[] = [
+      {
+        id: 'auto-node-a',
+        type: 'rectangle',
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, source: 'auto' },
+      },
+      { id: 'user-1', type: 'ellipse' },
+    ];
+    const { auto, user } = partitionElements(elements);
+    expect(auto).toHaveLength(1);
+    expect(user).toHaveLength(1);
+    expect(isAutoElement(auto[0])).toBe(true);
+    expect(isAutoElement(user[0])).toBe(false);
+  });
+});
+
+describe('setAutoElementsLocked', () => {
+  it('toggles locked only on auto elements', () => {
+    const elements: ExcalidrawElementStub[] = [
+      {
+        id: 'auto-node-a',
+        type: 'rectangle',
+        locked: true,
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, source: 'auto' },
+      },
+      { id: 'user-1', type: 'ellipse', locked: false },
+    ];
+    const updated = setAutoElementsLocked(elements, false);
+    expect(updated[0].locked).toBe(false);
+    expect(updated[1].locked).toBe(false);
+  });
+});

--- a/frontend/src/graph/converter.test.ts
+++ b/frontend/src/graph/converter.test.ts
@@ -1,7 +1,28 @@
+let randomIdCounter = 0;
+function nextRandomId(): string {
+  randomIdCounter += 1;
+  return `random-id-${randomIdCounter}`;
+}
+
 jest.mock('@excalidraw/excalidraw', () => ({
-  convertToExcalidrawElements: (skeletons: Array<Record<string, unknown>>) => {
-    // Simulate Excalidraw's behavior: container `label` becomes a separate text element
-    // with a containerId pointing back to the container.
+  // Simulate Excalidraw's actual behavior: by default `regenerateIds` is true,
+  // so every skeleton.id is replaced with a fresh random id. Bound text and
+  // arrow bindings must use the *new* container id, not the skeleton id.
+  convertToExcalidrawElements: (
+    skeletons: Array<Record<string, unknown>>,
+    opts?: { regenerateIds?: boolean },
+  ) => {
+    const regenerate = opts?.regenerateIds !== false;
+    const idMap = new Map<string, string>();
+    const resolveId = (originalId: string): string => {
+      if (!regenerate) return originalId;
+      const cached = idMap.get(originalId);
+      if (cached) return cached;
+      const next = nextRandomId();
+      idMap.set(originalId, next);
+      return next;
+    };
+
     const out: Array<Record<string, unknown>> = [];
     for (const skel of skeletons) {
       if (skel.type === 'rectangle' && skel.label) {
@@ -12,35 +33,55 @@ jest.mock('@excalidraw/excalidraw', () => ({
           y: number;
           locked?: boolean;
         };
-        out.push({ ...rest, boundElements: [{ id: `${rest.id}-label`, type: 'text' }] });
+        const containerId = resolveId(rest.id);
+        const labelId = `${containerId}-label`;
         out.push({
-          id: `${rest.id}-label`,
+          ...rest,
+          id: containerId,
+          boundElements: [{ id: labelId, type: 'text' }],
+        });
+        out.push({
+          id: labelId,
           type: 'text',
           x: rest.x,
           y: rest.y,
           width: 100,
           height: 20,
           text: label.text,
-          containerId: rest.id,
+          containerId,
           fontSize: label.fontSize,
           strokeColor: label.strokeColor,
           locked: rest.locked ?? false,
         });
       } else if (skel.type === 'arrow') {
-        const start = (skel as { start?: { id: string } }).start;
-        const end = (skel as { end?: { id: string } }).end;
+        const start = (skel as { start?: { id: string }; id: string }).start;
+        const end = (skel as { end?: { id: string }; id: string }).end;
+        const arrowId = resolveId((skel as { id: string }).id);
         out.push({
           ...skel,
-          startBinding: start ? { elementId: start.id, focus: 0, gap: 0 } : undefined,
-          endBinding: end ? { elementId: end.id, focus: 0, gap: 0 } : undefined,
+          id: arrowId,
+          startBinding: start
+            ? { elementId: resolveId(start.id), focus: 0, gap: 0 }
+            : undefined,
+          endBinding: end
+            ? { elementId: resolveId(end.id), focus: 0, gap: 0 }
+            : undefined,
         });
       } else {
-        out.push(skel);
+        const original = (skel as { id?: string }).id;
+        out.push({
+          ...skel,
+          id: typeof original === 'string' ? resolveId(original) : nextRandomId(),
+        });
       }
     }
     return out;
   },
 }));
+
+beforeEach(() => {
+  randomIdCounter = 0;
+});
 
 import {
   convertGraphToElements,
@@ -139,6 +180,31 @@ describe('convertGraphToElements', () => {
     const orphanEdges: GraphEdge[] = [{ from: 'a', to: 'missing' }];
     const { elements } = convertGraphToElements(sampleNodes, orphanEdges);
     expect(elements.find((e) => e.type === 'arrow')).toBeUndefined();
+  });
+
+  it('stamps customData on bound labels even when Excalidraw would regenerate ids', () => {
+    // Regression: convertToExcalidrawElements defaults to regenerateIds=true.
+    // We pass regenerateIds: false so containerIds keep their `auto-node-{id}`
+    // shape and stampAutoCustomData can mark labels as auto.
+    const { elements } = convertGraphToElements(sampleNodes, sampleEdges);
+    const labels = elements.filter((e) => e.type === 'text');
+    expect(labels.length).toBeGreaterThan(0);
+    for (const label of labels) {
+      const data = label.customData as { kind: string; source?: string; nodeId?: string };
+      expect(data?.source).toBe('auto');
+      expect(data?.kind).toBe(GRAPH_ELEMENT_KIND_NODE);
+      expect(typeof data?.nodeId).toBe('string');
+    }
+  });
+
+  it('does not leak labels into the user partition on a re-render cycle', () => {
+    // Simulate the App.tsx flow: first analysis -> partition -> second analysis
+    // with the user side preserved. If labels are not stamped as auto, they
+    // would accumulate as stale "user" elements across re-analyses.
+    const first = convertGraphToElements(sampleNodes, sampleEdges).elements;
+    const { user, auto } = partitionElements(first);
+    expect(user).toHaveLength(0);
+    expect(auto.length).toBe(first.length);
   });
 });
 

--- a/frontend/src/graph/converter.ts
+++ b/frontend/src/graph/converter.ts
@@ -106,10 +106,17 @@ export function convertGraphToElements(
     });
   }
 
-  const built = convertToExcalidrawElements(skeletons) as unknown as ExcalidrawElement[];
+  // Keep deterministic ids so bound text containerId / arrow bindings still
+  // reference the `auto-node-{nodeId}` ids we generated. Without this Excalidraw
+  // regenerates ids and we lose the ability to stamp customData on labels by
+  // matching containerId, which causes stale labels to leak into the user
+  // partition on re-analysis.
+  const built = convertToExcalidrawElements(skeletons, {
+    regenerateIds: false,
+  }) as unknown as ExcalidrawElement[];
 
-  // Propagate customData (Excalidraw's convertToExcalidrawElements drops it on arrows in
-  // some versions; re-stamp to be safe and ensure label text inherits source=auto).
+  // Stamp customData on auto-generated bound labels so partitionElements()
+  // and the lock toggle treat them as auto elements.
   const stubs = built.map((element) => stampAutoCustomData(element as unknown as ExcalidrawElementStub));
 
   return { elements: stubs, positions: merged };

--- a/frontend/src/graph/converter.ts
+++ b/frontend/src/graph/converter.ts
@@ -1,0 +1,181 @@
+import { convertToExcalidrawElements } from '@excalidraw/excalidraw';
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
+import type { ExcalidrawElementSkeleton } from '@excalidraw/excalidraw/data/transform';
+
+import type { ExcalidrawElementStub } from '../types/CanvasDocument';
+import { layoutGraph, NODE_HEIGHT, NODE_WIDTH, type LayoutPosition } from './layout';
+import {
+  GRAPH_ELEMENT_KIND_EDGE,
+  GRAPH_ELEMENT_KIND_NODE,
+  edgeKey,
+  type GraphCustomData,
+  type GraphEdge,
+  type GraphNode,
+} from './types';
+
+const AUTO_NODE_BG = '#eef2ff';
+const AUTO_NODE_STROKE = '#4f46e5';
+const AUTO_EDGE_STROKE = '#4f46e5';
+
+export interface ConvertOptions {
+  locked?: boolean;
+}
+
+export interface ConvertResult {
+  elements: ExcalidrawElementStub[];
+  positions: Map<string, LayoutPosition>;
+}
+
+function nodeElementId(nodeId: string): string {
+  return `auto-node-${nodeId}`;
+}
+
+/**
+ * Builds Excalidraw elements for a call graph payload.
+ * Existing positions are preserved per node id; new nodes are placed via dagre layout.
+ * Uses Excalidraw's `convertToExcalidrawElements` so all required element fields
+ * (seed, version, boundElements, ...) are populated and bindings are wired.
+ */
+export function convertGraphToElements(
+  nodes: readonly GraphNode[],
+  edges: readonly GraphEdge[],
+  existingPositions: ReadonlyMap<string, LayoutPosition> = new Map(),
+  options: ConvertOptions = {},
+): ConvertResult {
+  const locked = options.locked ?? true;
+  const newNodes = nodes.filter((n) => !existingPositions.has(n.id));
+  const newEdges = edges.filter(
+    (e) => newNodes.some((n) => n.id === e.from) || newNodes.some((n) => n.id === e.to),
+  );
+  const fresh = layoutGraph(newNodes, newEdges);
+
+  const merged = new Map<string, LayoutPosition>();
+  for (const node of nodes) {
+    const pos = existingPositions.get(node.id) ?? fresh.get(node.id);
+    if (pos) merged.set(node.id, pos);
+  }
+
+  const skeletons: ExcalidrawElementSkeleton[] = [];
+
+  for (const node of nodes) {
+    const pos = merged.get(node.id);
+    if (!pos) continue;
+    const customData: GraphCustomData = {
+      kind: GRAPH_ELEMENT_KIND_NODE,
+      nodeId: node.id,
+      source: 'auto',
+    };
+    skeletons.push({
+      type: 'rectangle',
+      id: nodeElementId(node.id),
+      x: pos.x,
+      y: pos.y,
+      width: NODE_WIDTH,
+      height: NODE_HEIGHT,
+      strokeColor: AUTO_NODE_STROKE,
+      backgroundColor: AUTO_NODE_BG,
+      fillStyle: 'solid',
+      roundness: { type: 3 },
+      locked,
+      customData,
+      label: {
+        text: node.name,
+        fontSize: 14,
+        strokeColor: AUTO_NODE_STROKE,
+      },
+    });
+  }
+
+  for (const edge of edges) {
+    if (!merged.has(edge.from) || !merged.has(edge.to)) continue;
+    const customData: GraphCustomData = {
+      kind: GRAPH_ELEMENT_KIND_EDGE,
+      edgeKey: edgeKey(edge),
+      source: 'auto',
+    };
+    skeletons.push({
+      type: 'arrow',
+      id: `auto-edge-${edgeKey(edge)}`,
+      x: 0,
+      y: 0,
+      strokeColor: AUTO_EDGE_STROKE,
+      locked,
+      customData,
+      start: { id: nodeElementId(edge.from) },
+      end: { id: nodeElementId(edge.to) },
+    });
+  }
+
+  const built = convertToExcalidrawElements(skeletons) as unknown as ExcalidrawElement[];
+
+  // Propagate customData (Excalidraw's convertToExcalidrawElements drops it on arrows in
+  // some versions; re-stamp to be safe and ensure label text inherits source=auto).
+  const stubs = built.map((element) => stampAutoCustomData(element as unknown as ExcalidrawElementStub));
+
+  return { elements: stubs, positions: merged };
+}
+
+function stampAutoCustomData(element: ExcalidrawElementStub): ExcalidrawElementStub {
+  const existing = element.customData as GraphCustomData | undefined;
+  if (existing?.source === 'auto') return element;
+
+  // Bound text inside an auto-node container: tag as graphNode with parent's nodeId.
+  if (element.type === 'text' && typeof element.containerId === 'string') {
+    const containerId = element.containerId;
+    if (containerId.startsWith('auto-node-')) {
+      const nodeId = containerId.replace(/^auto-node-/, '');
+      return {
+        ...element,
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId, source: 'auto' },
+      };
+    }
+  }
+  return element;
+}
+
+export function isAutoElement(element: ExcalidrawElementStub): boolean {
+  const data = element.customData as GraphCustomData | undefined;
+  return data?.source === 'auto';
+}
+
+export function extractPositions(
+  elements: readonly ExcalidrawElementStub[],
+): Map<string, LayoutPosition> {
+  const positions = new Map<string, LayoutPosition>();
+  for (const element of elements) {
+    if (element.type !== 'rectangle') continue;
+    const data = element.customData as GraphCustomData | undefined;
+    if (data?.kind !== GRAPH_ELEMENT_KIND_NODE) continue;
+    const nodeId = data.nodeId;
+    if (typeof nodeId !== 'string') continue;
+    const x = element.x;
+    const y = element.y;
+    if (typeof x !== 'number' || typeof y !== 'number') continue;
+    positions.set(nodeId, { x, y });
+  }
+  return positions;
+}
+
+export function partitionElements(
+  elements: readonly ExcalidrawElementStub[],
+): { auto: ExcalidrawElementStub[]; user: ExcalidrawElementStub[] } {
+  const auto: ExcalidrawElementStub[] = [];
+  const user: ExcalidrawElementStub[] = [];
+  for (const element of elements) {
+    if (isAutoElement(element)) {
+      auto.push(element);
+    } else {
+      user.push(element);
+    }
+  }
+  return { auto, user };
+}
+
+export function setAutoElementsLocked(
+  elements: readonly ExcalidrawElementStub[],
+  locked: boolean,
+): ExcalidrawElementStub[] {
+  return elements.map((element) =>
+    isAutoElement(element) ? { ...element, locked } : element,
+  );
+}

--- a/frontend/src/graph/layout.test.ts
+++ b/frontend/src/graph/layout.test.ts
@@ -1,0 +1,46 @@
+import { layoutGraph } from './layout';
+import type { GraphEdge, GraphNode } from './types';
+
+if (typeof (globalThis as { structuredClone?: unknown }).structuredClone !== 'function') {
+  (globalThis as { structuredClone: typeof structuredClone }).structuredClone = (value: unknown) =>
+    JSON.parse(JSON.stringify(value));
+}
+
+const node = (id: string): GraphNode => ({
+  id,
+  name: id,
+  kind: 'function',
+  file: `${id}.ts`,
+  range: { startLine: 0, startColumn: 0, endLine: 0, endColumn: 0 },
+});
+
+describe('layoutGraph', () => {
+  it('returns a position for every node', () => {
+    const nodes = [node('a'), node('b'), node('c')];
+    const edges: GraphEdge[] = [
+      { from: 'a', to: 'b' },
+      { from: 'b', to: 'c' },
+    ];
+    const positions = layoutGraph(nodes, edges);
+    expect(positions.size).toBe(3);
+    for (const id of ['a', 'b', 'c']) {
+      const pos = positions.get(id);
+      expect(pos).toBeDefined();
+      expect(typeof pos?.x).toBe('number');
+      expect(typeof pos?.y).toBe('number');
+    }
+  });
+
+  it('places connected nodes at distinct x positions for LR layout', () => {
+    const nodes = [node('a'), node('b')];
+    const edges: GraphEdge[] = [{ from: 'a', to: 'b' }];
+    const positions = layoutGraph(nodes, edges);
+    expect(positions.get('a')?.x).not.toBe(positions.get('b')?.x);
+  });
+
+  it('skips edges that reference unknown nodes', () => {
+    const nodes = [node('a')];
+    const edges: GraphEdge[] = [{ from: 'a', to: 'missing' }];
+    expect(() => layoutGraph(nodes, edges)).not.toThrow();
+  });
+});

--- a/frontend/src/graph/layout.ts
+++ b/frontend/src/graph/layout.ts
@@ -1,0 +1,57 @@
+import dagre from '@dagrejs/dagre';
+import type { GraphEdge, GraphNode } from './types';
+
+export const NODE_WIDTH = 200;
+export const NODE_HEIGHT = 60;
+
+export interface LayoutPosition {
+  x: number;
+  y: number;
+}
+
+export interface LayoutOptions {
+  width?: number;
+  height?: number;
+  rankdir?: 'TB' | 'LR' | 'BT' | 'RL';
+  ranksep?: number;
+  nodesep?: number;
+}
+
+export function layoutGraph(
+  nodes: readonly GraphNode[],
+  edges: readonly GraphEdge[],
+  options: LayoutOptions = {},
+): Map<string, LayoutPosition> {
+  const g = new dagre.graphlib.Graph();
+  g.setGraph({
+    rankdir: options.rankdir ?? 'LR',
+    ranksep: options.ranksep ?? 80,
+    nodesep: options.nodesep ?? 40,
+  });
+  g.setDefaultEdgeLabel(() => ({}));
+
+  const w = options.width ?? NODE_WIDTH;
+  const h = options.height ?? NODE_HEIGHT;
+
+  for (const node of nodes) {
+    g.setNode(node.id, { width: w, height: h });
+  }
+  for (const edge of edges) {
+    if (g.hasNode(edge.from) && g.hasNode(edge.to)) {
+      g.setEdge(edge.from, edge.to);
+    }
+  }
+
+  dagre.layout(g);
+
+  const positions = new Map<string, LayoutPosition>();
+  for (const node of nodes) {
+    const dagreNode = g.node(node.id);
+    if (!dagreNode) continue;
+    positions.set(node.id, {
+      x: dagreNode.x - w / 2,
+      y: dagreNode.y - h / 2,
+    });
+  }
+  return positions;
+}

--- a/frontend/src/graph/types.ts
+++ b/frontend/src/graph/types.ts
@@ -1,0 +1,83 @@
+import { isNonEmptyString, isRecord } from '../types/utils';
+
+export type GraphNodeKind = 'function' | 'method' | 'arrow';
+
+export interface GraphSourceRange {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}
+
+export interface GraphNode {
+  id: string;
+  name: string;
+  kind: GraphNodeKind;
+  file: string;
+  range: GraphSourceRange;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  unresolved?: boolean;
+}
+
+export interface CallGraphPayload {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export const GRAPH_ELEMENT_KIND_NODE = 'graphNode' as const;
+export const GRAPH_ELEMENT_KIND_EDGE = 'graphEdge' as const;
+
+export type GraphElementKind =
+  | typeof GRAPH_ELEMENT_KIND_NODE
+  | typeof GRAPH_ELEMENT_KIND_EDGE;
+
+export interface GraphCustomData {
+  kind: GraphElementKind;
+  nodeId?: string;
+  edgeKey?: string;
+  source?: 'auto';
+}
+
+export function isGraphNode(value: unknown): value is GraphNode {
+  if (!isRecord(value)) return false;
+  return (
+    isNonEmptyString(value.id) &&
+    isNonEmptyString(value.name) &&
+    isNonEmptyString(value.file)
+  );
+}
+
+export function isGraphEdge(value: unknown): value is GraphEdge {
+  if (!isRecord(value)) return false;
+  return isNonEmptyString(value.from) && isNonEmptyString(value.to);
+}
+
+export function isCallGraphPayload(value: unknown): value is CallGraphPayload {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.nodes) &&
+    value.nodes.every(isGraphNode) &&
+    Array.isArray(value.edges) &&
+    value.edges.every(isGraphEdge)
+  );
+}
+
+export function edgeKey(edge: GraphEdge): string {
+  return `${edge.from}->${edge.to}`;
+}
+
+export const ANALYSIS_MESSAGE_TYPE = 'analysis' as const;
+
+export interface AnalysisMessage {
+  type: typeof ANALYSIS_MESSAGE_TYPE;
+  payload: CallGraphPayload;
+}
+
+export function isAnalysisMessage(value: unknown): value is AnalysisMessage {
+  if (!isRecord(value)) return false;
+  return value.type === ANALYSIS_MESSAGE_TYPE && isCallGraphPayload(value.payload);
+}

--- a/frontend/src/vscodeBridge.ts
+++ b/frontend/src/vscodeBridge.ts
@@ -1,9 +1,13 @@
+import type { CallGraphPayload } from './graph/types';
+
 export type CodetraceUpdateHandler = (content: string) => void;
+export type CodetraceAnalysisHandler = (payload: CallGraphPayload) => void;
 
 declare global {
   interface Window {
     __codetrace_initialContent?: string;
     __codetrace_onUpdate?: CodetraceUpdateHandler;
+    __codetrace_onAnalysis?: CodetraceAnalysisHandler;
     __codetrace_save?: (content: string) => void;
     __codetrace_saveFile?: (content: string) => void;
   }
@@ -19,6 +23,15 @@ export function subscribeDocumentUpdates(handler: CodetraceUpdateHandler): () =>
 
   return () => {
     window.__codetrace_onUpdate = previousHandler;
+  };
+}
+
+export function subscribeAnalysisUpdates(handler: CodetraceAnalysisHandler): () => void {
+  const previousHandler = window.__codetrace_onAnalysis;
+  window.__codetrace_onAnalysis = handler;
+
+  return () => {
+    window.__codetrace_onAnalysis = previousHandler;
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       "name": "codetrace-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dagrejs/dagre": "^3.0.0",
         "@excalidraw/excalidraw": "^0.18.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
@@ -2851,6 +2852,21 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@dagrejs/dagre": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
+      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@dagrejs/graphlib": "4.0.1"
+      }
+    },
+    "node_modules/@dagrejs/graphlib": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
+      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",


### PR DESCRIPTION
## Summary
- 분석기 호출 그래프(`CallGraph`)를 Excalidraw element로 변환해 자동 렌더 (§C4·C7)
- 신규 노드는 dagre로 레이아웃, 기존 사용자 배치는 노드 ID로 보존 (§C6)
- 자동 element는 default `locked: true`, 토글 버튼으로 일괄 해제
- extension ↔ webview postMessage 컨트랙트 정의 (`{type:'analysis', payload: CallGraphPayload}`)
- 분석 결과 출력 경로를 `.codetrace/analysis_cache.json`로 정규화 (§H5)

## Changes
- `frontend/src/graph/types.ts`: `CallGraphPayload`, `GraphCustomData`, `AnalysisMessage` 메시지 컨트랙트 추가
- `frontend/src/graph/layout.ts`: dagre 기반 레이아웃 (LR, ranksep 80, nodesep 40) 신규
- `frontend/src/graph/converter.ts`: `convertToExcalidrawElements` 사용해 element 생성·위치 머지·partition·잠금 토글
- `frontend/src/App.tsx`: analysis 메시지 구독, 자동 노드 잠금 토글 UI
- `frontend/src/vscodeBridge.ts`: `subscribeAnalysisUpdates` 추가
- `extension/src/CanvasEditorProvider.ts`: `activePanels` 레지스트리 + `broadcast` 정적 메서드, webview inline script에 analysis 메시지 디스패치
- `extension/src/extension.ts`: 분석 후 `.codetrace/analysis_cache.json` 저장 + webview broadcast
- `frontend/package.json`: `@dagrejs/dagre` 재추가

## Related Issue
Closes #69

## Test plan
- [x] 단위 테스트 14건 통과 (`frontend/src/graph/*.test.ts`)
  - 변환기: element 종류·`customData.kind`·`source: 'auto'`·잠금 default·잠금 옵션 반영·위치 보존·고아 위치 파기·arrow binding·고아 엣지 skip
  - 레이아웃: 모든 노드 좌표 반환·LR에서 연결 노드 x 분리·미존재 노드 참조 시 throw 안 함
  - partition / setAutoElementsLocked / extractPositions
- [x] frontend 전체 jest (39건) 통과
- [x] frontend `tsc --noEmit` 통과
- [x] frontend `vite build` 통과
- [x] extension `esbuild` 통과
- [ ] **Webview 실행 검증 미완료** — VS Code Extension Host (F5)에서 수동 검증 필요:
  1. `.codetrace` 캔버스 연 상태에서 `CodeTrace: Analyze Workspace` 실행 → 자동 노드/엣지 렌더 여부
  2. 노드를 드래그해 위치 변경 → 재분석 시 위치 보존 여부
  3. 잠금 토글 버튼 → 자동 노드가 이동/편집 가능해지는지
  4. arrow가 노드 이동을 따라가는지 (binding 정상 동작)

## 알려진 위험 (수동 검증 필요)
- **Excalidraw element 필드 완전성**: `convertToExcalidrawElements`로 생성하므로 `seed`/`version`/`boundElements` 등 자동 채움이 기대되지만, 실제 webview에서 `getSceneElements()`와 비교 필요
- **Bound text/arrow binding**: `label` 옵션과 `start`/`end` 참조로 위임했으나, 일부 버전에서 customData 누락 가능성. `stampAutoCustomData`로 보강했지만 webview 확인 필요
- **토글 버튼 위치**: `top: 12, right: 12`가 Excalidraw 라이브러리 메뉴와 겹칠 수 있음 — 검증 후 위치 조정 검토

## Out of scope
- 노드 삭제 시 caller 분석 다이얼로그 (§C6 후속) → #72
- 포스트잇 도구 → #70
- 사용자 그린 화살표/텍스트 툴바 커스터마이징 → #73