### PR TITLE
fix(ci): restrict Claude workflows to known collaborators

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Restrict automatic PR reviews to PRs opened by the project's known
+    # collaborators so that fork PRs from outside contributors do not consume
+    # our subscription/API quota.
+    if: |
+      github.event.pull_request.user.login == 'jinsh1210' ||
+      github.event.pull_request.user.login == 'jjk03' ||
+      github.event.pull_request.user.login == '2sThisE' ||
+      github.event.pull_request.user.login == 'babytazo'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,20 @@ on:
 
 jobs:
   claude:
+    # Restrict @claude triggers to the project's known collaborators so that
+    # outside contributors cannot rack up subscription/API usage on our account.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.actor == 'jinsh1210' ||
+        github.actor == 'jjk03' ||
+        github.actor == '2sThisE' ||
+        github.actor == 'babytazo'
+      ) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ desktop.ini
 *.swp
 *.swo
 .next/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

설치된 Claude GitHub Actions 워크플로 2개에 collaborator 화이트리스트를 적용해, 외부 기여자가 우리 계정의 Claude 구독/API 한도를 소진하는 것을 차단합니다.

화이트리스트: `jinsh1210`, `jjk03`, `2sThisE`, `babytazo`

## Changes

- `.github/workflows/claude.yml`: `@claude` 멘션 트리거에 `github.actor` 화이트리스트 게이트 추가
- `.github/workflows/claude-code-review.yml`: 자동 PR 리뷰에 `pull_request.user.login` 화이트리스트 게이트 추가
- `.gitignore`: `.claude/settings.local.json` 무시 (개인 에디터 설정)

## Related Issue

없음 (워크플로 설치 직후 노출 차단을 위한 즉시 적용성 변경)

## 배경

`/install-github-app`으로 두 워크플로가 main에 머지된 직후 본 PR을 작성. 기본 설정은 화이트리스트 없이 누구나 트리거 가능한 상태였음:
- `claude.yml`: 어떤 사용자든 `@claude` 멘션으로 호출 가능
- `claude-code-review.yml`: 모든 PR(외부 fork 포함)에 자동 리뷰 실행

두 경로 모두 우리 계정으로 비용 청구되므로 신뢰할 수 있는 collaborator만 허용.

## Test plan

- [x] YAML syntax 점검 (들여쓰기, 조건식 평가 우선순위)
- [ ] 머지 후 jinsh1210/jjk03/2sThisE/babytazo 외 사용자가 멘션·PR 시 워크플로가 skip되는지 Actions 로그로 확인
- [ ] 본인이 `@claude` 멘션 시 정상 트리거되는지 확인