### PR TITLE
chore: sync main into develop (Claude workflows + allowlist)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,14 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Restrict automatic PR reviews to PRs opened by the project's known
+    # collaborators so that fork PRs from outside contributors do not consume
+    # our subscription/API quota.
+    if: |
+      github.event.pull_request.user.login == 'jinsh1210' ||
+      github.event.pull_request.user.login == 'jjk03' ||
+      github.event.pull_request.user.login == '2sThisE' ||
+      github.event.pull_request.user.login == 'babytazo'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,11 +12,20 @@ on:
 
 jobs:
   claude:
+    # Restrict @claude triggers to the project's known collaborators so that
+    # outside contributors cannot rack up subscription/API usage on our account.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.actor == 'jinsh1210' ||
+        github.actor == 'jjk03' ||
+        github.actor == '2sThisE' ||
+        github.actor == 'babytazo'
+      ) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ desktop.ini
 *.swp
 *.swo
 .next/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

main에만 있던 Claude GitHub Actions 워크플로 2개와 화이트리스트 패치(#79)를 develop으로 동기화합니다.

## Changes

- `.github/workflows/claude.yml` 추가 (main에서 가져옴, `@claude` 멘션 트리거)
- `.github/workflows/claude-code-review.yml` 추가 (main에서 가져옴, 자동 PR 리뷰)
- 두 워크플로 모두 `jinsh1210`/`jjk03`/`2sThisE`/`babytazo` 화이트리스트 적용 상태 (PR #79)
- `.gitignore` 충돌 해소 (develop의 기존 항목 유지, main의 `.claude/settings.local.json`은 이미 `.claude/` 와일드카드로 커버됨)

## Related Issue

없음 (브랜치 동기화)

## 배경

`/install-github-app`이 워크플로를 main에 직접 머지(PR #78)했고, 그 직후 화이트리스트 패치(PR #79)도 main에 머지되었음. develop은 두 변경 모두 누락된 상태라 develop 기반 PR을 열면 Claude 자동 리뷰가 작동하지 않음.

## Test plan

- [x] `.gitignore` 충돌 해소 검증 (claude/settings.local.json은 `.claude/` 와일드카드로 이미 커버, 중복 라인은 그대로 유지하여 main과 정합성 보존)
- [x] develop에 워크플로 2개와 화이트리스트가 main과 동일한 내용으로 들어왔는지 확인
- [ ] 머지 후 develop 기반 다음 PR에서 Claude 자동 리뷰가 작동하는지 (단, 화이트리스트 collaborator가 연 PR에 한해)