### PR TITLE
feat(frontend): 포스트잇 도구 — 부착/작성/저장/임시/취소 UX (#70)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@excalidraw/excalidraw": "^0.18.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "ulid": "^3.0.2",
     "yjs": "^13.6.30"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,14 @@ import {
   partitionElements,
   setAutoElementsLocked,
 } from './graph/converter';
-import type { CallGraphPayload } from './graph/types';
+import { GRAPH_ELEMENT_KIND_NODE, type CallGraphPayload, type GraphCustomData } from './graph/types';
+import {
+  commitSticky,
+  createStickyForAnchor,
+  removeSticky,
+  updateStickyText,
+} from './sticky/sticky';
+import { isReviewStickyCustomData } from './sticky/types';
 import {
   getInitialDocumentContent,
   saveDocumentContent,
@@ -33,8 +40,41 @@ import {
 
 type ExcalidrawChangeHandler = NonNullable<ComponentProps<typeof Excalidraw>['onChange']>;
 
+interface DraftEditorState {
+  reviewId: string;
+  title: string;
+  body: string;
+}
+
 function readInitialDocument() {
   return parseCanvasDocumentContent(getInitialDocumentContent() ?? '');
+}
+
+function findGraphNodeAnchor(element: ExcalidrawElementStub | null | undefined): {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+} | null {
+  if (!element) return null;
+  const data = element.customData as GraphCustomData | undefined;
+  if (data?.kind !== GRAPH_ELEMENT_KIND_NODE) return null;
+  // Labels carry the same kind but live as text inside the rectangle.
+  if (element.type !== 'rectangle') return null;
+  const x = element.x;
+  const y = element.y;
+  const width = element.width;
+  const height = element.height;
+  if (
+    typeof x !== 'number' ||
+    typeof y !== 'number' ||
+    typeof width !== 'number' ||
+    typeof height !== 'number'
+  ) {
+    return null;
+  }
+  return { id: String(element.id), x, y, width, height };
 }
 
 export default function App() {
@@ -47,6 +87,13 @@ export default function App() {
   const latestContentRef = useRef<string>(initialContent);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [autoLocked, setAutoLocked] = useState(true);
+  const [stickyMode, setStickyMode] = useState(false);
+  const stickyModeRef = useRef(stickyMode);
+  const [draft, setDraft] = useState<DraftEditorState | null>(null);
+
+  useEffect(() => {
+    stickyModeRef.current = stickyMode;
+  }, [stickyMode]);
 
   useEffect(() => {
     cardsRef.current = initialDocument.cards;
@@ -97,6 +144,8 @@ export default function App() {
 
       const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
       const { user } = partitionElements(current);
+      const stickyElements = current.filter((el) => isReviewStickyCustomData(el.customData));
+      const userOnly = user.filter((el) => !isReviewStickyCustomData(el.customData));
       const existingPositions = extractPositions(current);
 
       const { elements: autoElements } = convertGraphToElements(
@@ -106,7 +155,7 @@ export default function App() {
         { locked: autoLocked },
       );
 
-      const next = [...autoElements, ...user];
+      const next = [...autoElements, ...userOnly, ...stickyElements];
       api.updateScene({
         elements: next as unknown as ExcalidrawElement[],
         captureUpdate: CaptureUpdateAction.IMMEDIATELY,
@@ -137,6 +186,32 @@ export default function App() {
     apiRef.current = api;
   }, []);
 
+  // Wire post-it click-to-attach: when sticky mode is on, the next click on a
+  // graphNode rectangle creates a draft sticky anchored to that node.
+  useEffect(() => {
+    const api = apiRef.current;
+    if (!api) return;
+    const unsubscribe = api.onPointerDown((_tool, pointerDownState) => {
+      if (!stickyModeRef.current) return;
+      const hit = pointerDownState.hit?.element as ExcalidrawElementStub | null;
+      const anchor = findGraphNodeAnchor(hit);
+      if (!anchor) return;
+
+      const { reviewId, elements: stickyElements } = createStickyForAnchor(anchor, {
+        title: '',
+        body: '',
+      });
+      const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+      api.updateScene({
+        elements: [...current, ...stickyElements] as unknown as ExcalidrawElement[],
+        captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+      });
+      setStickyMode(false);
+      setDraft({ reviewId, title: '', body: '' });
+    });
+    return unsubscribe;
+  }, [apiRef.current]);
+
   const handleChange = useCallback<ExcalidrawChangeHandler>(
     (elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {
       const document = createCanvasDocumentFromScene({
@@ -155,27 +230,174 @@ export default function App() {
     [],
   );
 
+  const handleDraftChange = useCallback(
+    (patch: Partial<Pick<DraftEditorState, 'title' | 'body'>>) => {
+      setDraft((prev) => (prev ? { ...prev, ...patch } : prev));
+    },
+    [],
+  );
+
+  const handleDraftSave = useCallback(() => {
+    setDraft((prev) => {
+      if (!prev) return prev;
+      const api = apiRef.current;
+      if (api) {
+        const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+        const withText = updateStickyText(current, prev.reviewId, prev.title, prev.body);
+        const committed = commitSticky(withText, prev.reviewId);
+        api.updateScene({
+          elements: committed as unknown as ExcalidrawElement[],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      }
+      return null;
+    });
+  }, []);
+
+  const handleDraftCancel = useCallback(() => {
+    setDraft((prev) => {
+      if (!prev) return prev;
+      const api = apiRef.current;
+      if (api) {
+        const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+        const without = removeSticky(current, prev.reviewId);
+        api.updateScene({
+          elements: without as unknown as ExcalidrawElement[],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      }
+      return null;
+    });
+  }, []);
+
+  const toggleStickyMode = useCallback(() => {
+    setStickyMode((prev) => !prev);
+  }, []);
+
   return (
     <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
-      <button
-        type="button"
-        onClick={toggleAutoLock}
+      <div
         style={{
           position: 'absolute',
           top: 12,
           right: 12,
           zIndex: 10,
-          padding: '6px 10px',
-          fontSize: 12,
-          background: autoLocked ? '#eef2ff' : '#fef3c7',
-          border: '1px solid #4f46e5',
-          borderRadius: 6,
-          cursor: 'pointer',
+          display: 'flex',
+          gap: 8,
         }}
-        title="자동 생성 노드의 잠금을 토글합니다"
       >
-        {autoLocked ? '자동 노드 잠금' : '자동 노드 해제'}
-      </button>
+        <button
+          type="button"
+          onClick={toggleStickyMode}
+          style={{
+            padding: '6px 10px',
+            fontSize: 12,
+            background: stickyMode ? '#fde68a' : '#fef9c3',
+            border: '1px solid #ca8a04',
+            borderRadius: 6,
+            cursor: 'pointer',
+          }}
+          title="포스트잇 모드: 켜고 노드를 클릭하면 메모를 부착합니다"
+        >
+          {stickyMode ? '포스트잇 모드 ON (노드 클릭)' : '포스트잇'}
+        </button>
+        <button
+          type="button"
+          onClick={toggleAutoLock}
+          style={{
+            padding: '6px 10px',
+            fontSize: 12,
+            background: autoLocked ? '#eef2ff' : '#fef3c7',
+            border: '1px solid #4f46e5',
+            borderRadius: 6,
+            cursor: 'pointer',
+          }}
+          title="자동 생성 노드의 잠금을 토글합니다"
+        >
+          {autoLocked ? '자동 노드 잠금' : '자동 노드 해제'}
+        </button>
+      </div>
+
+      {draft && (
+        <div
+          style={{
+            position: 'absolute',
+            top: 60,
+            right: 12,
+            zIndex: 11,
+            width: 280,
+            padding: 12,
+            background: '#fef9c3',
+            border: '1px solid #ca8a04',
+            borderRadius: 8,
+            boxShadow: '0 6px 16px rgba(0,0,0,0.15)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+          }}
+        >
+          <input
+            type="text"
+            placeholder="제목"
+            value={draft.title}
+            onChange={(e) => handleDraftChange({ title: e.target.value })}
+            style={{
+              padding: '6px 8px',
+              fontSize: 13,
+              border: '1px solid #ca8a04',
+              borderRadius: 4,
+              background: '#fffbeb',
+            }}
+            autoFocus
+          />
+          <textarea
+            placeholder="본문"
+            value={draft.body}
+            onChange={(e) => handleDraftChange({ body: e.target.value })}
+            rows={4}
+            style={{
+              padding: '6px 8px',
+              fontSize: 13,
+              border: '1px solid #ca8a04',
+              borderRadius: 4,
+              background: '#fffbeb',
+              resize: 'vertical',
+            }}
+          />
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 6 }}>
+            <button
+              type="button"
+              onClick={handleDraftCancel}
+              style={{
+                padding: '4px 10px',
+                fontSize: 12,
+                background: 'transparent',
+                border: '1px solid #ca8a04',
+                borderRadius: 4,
+                cursor: 'pointer',
+              }}
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              onClick={handleDraftSave}
+              style={{
+                padding: '4px 10px',
+                fontSize: 12,
+                background: '#ca8a04',
+                color: 'white',
+                border: '1px solid #ca8a04',
+                borderRadius: 4,
+                cursor: 'pointer',
+              }}
+            >
+              저장
+            </button>
+          </div>
+        </div>
+      )}
+
       <Excalidraw
         excalidrawAPI={handleExcalidrawAPI}
         initialData={initialData as unknown as ExcalidrawInitialDataState}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -182,16 +182,16 @@ export default function App() {
     });
   }, []);
 
+  const pointerUnsubRef = useRef<(() => void) | null>(null);
+
+  // Register the post-it click-to-attach handler when the Excalidraw API
+  // becomes available. Subscribing inside this callback avoids the React-vs-ref
+  // race where a `useEffect([apiRef.current])` would never re-run after the
+  // ref is filled (refs do not trigger re-renders).
   const handleExcalidrawAPI = useCallback((api: ExcalidrawImperativeAPI) => {
     apiRef.current = api;
-  }, []);
-
-  // Wire post-it click-to-attach: when sticky mode is on, the next click on a
-  // graphNode rectangle creates a draft sticky anchored to that node.
-  useEffect(() => {
-    const api = apiRef.current;
-    if (!api) return;
-    const unsubscribe = api.onPointerDown((_tool, pointerDownState) => {
+    pointerUnsubRef.current?.();
+    pointerUnsubRef.current = api.onPointerDown((_tool, pointerDownState) => {
       if (!stickyModeRef.current) return;
       const hit = pointerDownState.hit?.element as ExcalidrawElementStub | null;
       const anchor = findGraphNodeAnchor(hit);
@@ -209,8 +209,14 @@ export default function App() {
       setStickyMode(false);
       setDraft({ reviewId, title: '', body: '' });
     });
-    return unsubscribe;
-  }, [apiRef.current]);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      pointerUnsubRef.current?.();
+      pointerUnsubRef.current = null;
+    };
+  }, []);
 
   const handleChange = useCallback<ExcalidrawChangeHandler>(
     (elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {

--- a/frontend/src/sticky/sticky.test.ts
+++ b/frontend/src/sticky/sticky.test.ts
@@ -204,6 +204,23 @@ describe('updateStickyText', () => {
     expect(label?.text).toBe('NEW\n\nBODY2');
     expect(label?.originalText).toBe('NEW\n\nBODY2');
   });
+
+  it('still produces a label element when sticky was created with empty text', () => {
+    // Regression for the App-level draft flow:
+    //   createStickyForAnchor(anchor, { title: '', body: '' })
+    //   -> updateStickyText(..., '제목', '본문')
+    // Previously Excalidraw skipped the label skeleton when text was empty,
+    // so updateStickyText found nothing to mutate and the user's typed text
+    // never reached the canvas. The placeholder label keeps the slot alive.
+    const { elements } = createStickyForAnchor(anchor, { reviewId: 'rEmpty', title: '', body: '' });
+    const labelBefore = elements.find((e) => e.type === 'text');
+    expect(labelBefore).toBeDefined();
+
+    const updated = updateStickyText(elements, 'rEmpty', '제목', '본문');
+    const labelAfter = updated.find((e) => e.type === 'text');
+    expect(labelAfter?.text).toBe('제목\n\n본문');
+    expect(labelAfter?.originalText).toBe('제목\n\n본문');
+  });
 });
 
 describe('listStickyGroups', () => {

--- a/frontend/src/sticky/sticky.test.ts
+++ b/frontend/src/sticky/sticky.test.ts
@@ -1,0 +1,237 @@
+let randomIdCounter = 0;
+function nextRandomId(): string {
+  randomIdCounter += 1;
+  return `random-id-${randomIdCounter}`;
+}
+
+jest.mock('@excalidraw/excalidraw', () => ({
+  convertToExcalidrawElements: (
+    skeletons: Array<Record<string, unknown>>,
+    opts?: { regenerateIds?: boolean },
+  ) => {
+    const regenerate = opts?.regenerateIds !== false;
+    const idMap = new Map<string, string>();
+    const resolveId = (id: string): string => {
+      if (!regenerate) return id;
+      const cached = idMap.get(id);
+      if (cached) return cached;
+      const next = nextRandomId();
+      idMap.set(id, next);
+      return next;
+    };
+
+    const out: Array<Record<string, unknown>> = [];
+    for (const skel of skeletons) {
+      if (skel.type === 'rectangle' && skel.label) {
+        const { label, ...rest } = skel as {
+          label: { text: string; fontSize?: number; strokeColor?: string };
+          id: string;
+          x: number;
+          y: number;
+          locked?: boolean;
+        };
+        const containerId = resolveId(rest.id);
+        const labelId = `${containerId}-label`;
+        out.push({
+          ...rest,
+          id: containerId,
+          boundElements: [{ id: labelId, type: 'text' }],
+        });
+        out.push({
+          id: labelId,
+          type: 'text',
+          x: rest.x,
+          y: rest.y,
+          width: 100,
+          height: 20,
+          text: label.text,
+          containerId,
+          fontSize: label.fontSize,
+          strokeColor: label.strokeColor,
+          locked: rest.locked ?? false,
+        });
+      } else if (skel.type === 'arrow') {
+        const start = (skel as { start?: { id: string }; id: string }).start;
+        const end = (skel as { end?: { id: string }; id: string }).end;
+        const arrowId = resolveId((skel as { id: string }).id);
+        out.push({
+          ...skel,
+          id: arrowId,
+          startBinding: start
+            ? { elementId: resolveId(start.id), focus: 0, gap: 0 }
+            : undefined,
+          endBinding: end
+            ? { elementId: resolveId(end.id), focus: 0, gap: 0 }
+            : undefined,
+        });
+      } else {
+        const original = (skel as { id?: string }).id;
+        out.push({
+          ...skel,
+          id: typeof original === 'string' ? resolveId(original) : nextRandomId(),
+        });
+      }
+    }
+    return out;
+  },
+}));
+
+beforeEach(() => {
+  randomIdCounter = 0;
+});
+
+import {
+  commitSticky,
+  createStickyForAnchor,
+  getStickyReviewId,
+  isStickyElement,
+  listStickyGroups,
+  removeSticky,
+  updateStickyText,
+  type AnchorBox,
+} from './sticky';
+import { STICKY_ELEMENT_KIND, type ReviewStickyCustomData } from './types';
+import type { ExcalidrawElementStub } from '../types/CanvasDocument';
+
+const anchor: AnchorBox = { id: 'auto-node-foo', x: 0, y: 0, width: 200, height: 60 };
+
+describe('createStickyForAnchor', () => {
+  it('produces a body rectangle and a connector arrow tagged as reviewSticky', () => {
+    const result = createStickyForAnchor(anchor, { reviewId: 'r1', title: 'hi', body: 'note' });
+    const rects = result.elements.filter((e) => e.type === 'rectangle');
+    const arrows = result.elements.filter((e) => e.type === 'arrow');
+    expect(rects).toHaveLength(1);
+    expect(arrows).toHaveLength(1);
+    for (const element of result.elements) {
+      const data = element.customData as ReviewStickyCustomData;
+      expect(data.kind).toBe(STICKY_ELEMENT_KIND);
+      expect(data.reviewId).toBe('r1');
+      expect(data.draft).toBe(true);
+      expect(data.anchorElementId).toBe(anchor.id);
+    }
+  });
+
+  it('marks the bound label as reviewSticky body so it does not leak into other partitions', () => {
+    const { elements } = createStickyForAnchor(anchor, { reviewId: 'r2', title: 't', body: 'b' });
+    const label = elements.find((e) => e.type === 'text');
+    expect(label).toBeDefined();
+    const data = label?.customData as ReviewStickyCustomData;
+    expect(data.kind).toBe(STICKY_ELEMENT_KIND);
+    expect(data.reviewId).toBe('r2');
+    expect(data.role).toBe('body');
+  });
+
+  it('keeps deterministic ids for body and connector', () => {
+    const { elements, bodyElementId, connectorElementId } = createStickyForAnchor(anchor, {
+      reviewId: 'r3',
+      title: 't',
+      body: 'b',
+    });
+    expect(bodyElementId).toBe('sticky-body-r3');
+    expect(connectorElementId).toBe('sticky-connector-r3');
+    expect(elements.find((e) => e.id === bodyElementId)).toBeDefined();
+    expect(elements.find((e) => e.id === connectorElementId)).toBeDefined();
+  });
+
+  it('binds the connector arrow from anchor to sticky body', () => {
+    const { elements, bodyElementId } = createStickyForAnchor(anchor, { reviewId: 'r4', title: 't', body: 'b' });
+    const arrow = elements.find((e) => e.type === 'arrow');
+    const startBinding = arrow?.startBinding as { elementId: string };
+    const endBinding = arrow?.endBinding as { elementId: string };
+    expect(startBinding?.elementId).toBe(anchor.id);
+    expect(endBinding?.elementId).toBe(bodyElementId);
+  });
+
+  it('uses dashed connector style and unlocked elements', () => {
+    const { elements } = createStickyForAnchor(anchor, { reviewId: 'r5' });
+    const arrow = elements.find((e) => e.type === 'arrow');
+    expect(arrow?.strokeStyle).toBe('dashed');
+    expect(elements.every((e) => e.locked === false)).toBe(true);
+  });
+
+  it('generates a ULID when reviewId is not provided', () => {
+    const a = createStickyForAnchor(anchor);
+    const b = createStickyForAnchor(anchor);
+    expect(a.reviewId).not.toBe(b.reviewId);
+    // Crockford base32, 26 chars
+    expect(a.reviewId).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+});
+
+describe('commitSticky', () => {
+  it('clears draft on every element of the matching reviewId', () => {
+    const { elements } = createStickyForAnchor(anchor, { reviewId: 'r6', title: 't', body: 'b' });
+    const committed = commitSticky(elements, 'r6');
+    for (const element of committed) {
+      const data = element.customData as ReviewStickyCustomData;
+      expect(data.draft).toBe(false);
+    }
+  });
+
+  it('leaves other reviewIds untouched', () => {
+    const a = createStickyForAnchor(anchor, { reviewId: 'rA', title: 't', body: 'b' }).elements;
+    const b = createStickyForAnchor(anchor, { reviewId: 'rB', title: 't', body: 'b' }).elements;
+    const merged = [...a, ...b];
+    const committed = commitSticky(merged, 'rA');
+    for (const element of committed) {
+      const data = element.customData as ReviewStickyCustomData;
+      if (data.reviewId === 'rA') expect(data.draft).toBe(false);
+      else expect(data.draft).toBe(true);
+    }
+  });
+});
+
+describe('removeSticky', () => {
+  it('drops body, connector, and label as a single group', () => {
+    const { elements } = createStickyForAnchor(anchor, { reviewId: 'r7', title: 't', body: 'b' });
+    const after = removeSticky(elements, 'r7');
+    expect(after).toHaveLength(0);
+  });
+
+  it('leaves unrelated elements intact', () => {
+    const sticky = createStickyForAnchor(anchor, { reviewId: 'r8', title: 't', body: 'b' }).elements;
+    const userShape: ExcalidrawElementStub = { id: 'user-1', type: 'ellipse' };
+    const after = removeSticky([...sticky, userShape], 'r8');
+    expect(after).toEqual([userShape]);
+  });
+});
+
+describe('updateStickyText', () => {
+  it('rewrites the label text without disturbing other elements', () => {
+    const { elements } = createStickyForAnchor(anchor, { reviewId: 'r9', title: 'old', body: 'body' });
+    const updated = updateStickyText(elements, 'r9', 'NEW', 'BODY2');
+    const label = updated.find((e) => e.type === 'text');
+    expect(label?.text).toBe('NEW\n\nBODY2');
+    expect(label?.originalText).toBe('NEW\n\nBODY2');
+  });
+});
+
+describe('listStickyGroups', () => {
+  it('groups body, label, and connector by reviewId', () => {
+    const a = createStickyForAnchor(anchor, { reviewId: 'rX', title: 't', body: 'b' }).elements;
+    const b = createStickyForAnchor(anchor, { reviewId: 'rY', title: 't', body: 'b' }).elements;
+    const groups = listStickyGroups([...a, ...b]);
+    expect(groups).toHaveLength(2);
+    for (const g of groups) {
+      expect(g.body).toBeDefined();
+      expect(g.connector).toBeDefined();
+      expect(g.label).toBeDefined();
+    }
+  });
+});
+
+describe('isStickyElement / getStickyReviewId', () => {
+  it('returns true and the reviewId for sticky elements', () => {
+    const { elements } = createStickyForAnchor(anchor, { reviewId: 'rZ', title: 't', body: 'b' });
+    for (const element of elements) {
+      expect(isStickyElement(element)).toBe(true);
+      expect(getStickyReviewId(element)).toBe('rZ');
+    }
+  });
+
+  it('returns false / undefined for non-sticky elements', () => {
+    const userShape: ExcalidrawElementStub = { id: 'u', type: 'ellipse' };
+    expect(isStickyElement(userShape)).toBe(false);
+    expect(getStickyReviewId(userShape)).toBeUndefined();
+  });
+});

--- a/frontend/src/sticky/sticky.ts
+++ b/frontend/src/sticky/sticky.ts
@@ -52,6 +52,14 @@ function defaultText(title: string, body: string): string {
 }
 
 /**
+ * Excalidraw skips creating a bound `label` element when the label text is empty.
+ * That breaks updateStickyText() later because there is no text element to mutate.
+ * Use a single space as a placeholder so the label slot exists from the start;
+ * updateStickyText overwrites it as soon as the user types anything.
+ */
+const EMPTY_LABEL_PLACEHOLDER = ' ';
+
+/**
  * Build a draft sticky note attached to the anchor element box.
  * Returns deterministic ids so the App layer can later locate the body for
  * editing or removal without scanning by reviewId again.
@@ -79,7 +87,7 @@ export function createStickyForAnchor(
     role: 'connector',
   };
 
-  const labelText = defaultText(options.title ?? '', options.body ?? '');
+  const labelText = defaultText(options.title ?? '', options.body ?? '') || EMPTY_LABEL_PLACEHOLDER;
 
   const skeletons: ExcalidrawElementSkeleton[] = [
     {
@@ -95,15 +103,13 @@ export function createStickyForAnchor(
       roundness: { type: 3 },
       locked: false,
       customData: body,
-      label: labelText
-        ? {
-            text: labelText,
-            fontSize: 14,
-            strokeColor: STICKY_STROKE,
-            textAlign: 'left',
-            verticalAlign: 'top',
-          }
-        : undefined,
+      label: {
+        text: labelText,
+        fontSize: 14,
+        strokeColor: STICKY_STROKE,
+        textAlign: 'left',
+        verticalAlign: 'top',
+      },
     },
     {
       type: 'arrow',

--- a/frontend/src/sticky/sticky.ts
+++ b/frontend/src/sticky/sticky.ts
@@ -1,0 +1,253 @@
+import { convertToExcalidrawElements } from '@excalidraw/excalidraw';
+import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
+import type { ExcalidrawElementSkeleton } from '@excalidraw/excalidraw/data/transform';
+import { ulid } from 'ulid';
+
+import type { ExcalidrawElementStub } from '../types/CanvasDocument';
+import { STICKY_ELEMENT_KIND, isReviewStickyCustomData, type ReviewStickyCustomData } from './types';
+
+export const STICKY_WIDTH = 200;
+export const STICKY_HEIGHT = 120;
+const STICKY_OFFSET_X = 32;
+const STICKY_OFFSET_Y = -32;
+
+const STICKY_BG = '#fef9c3';
+const STICKY_STROKE = '#ca8a04';
+const CONNECTOR_STROKE = '#ca8a04';
+
+export interface AnchorBox {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface CreateStickyOptions {
+  reviewId?: string;
+  title?: string;
+  body?: string;
+}
+
+export interface CreateStickyResult {
+  reviewId: string;
+  elements: ExcalidrawElementStub[];
+  bodyElementId: string;
+  connectorElementId: string;
+}
+
+function bodyElementId(reviewId: string): string {
+  return `sticky-body-${reviewId}`;
+}
+
+function connectorElementId(reviewId: string): string {
+  return `sticky-connector-${reviewId}`;
+}
+
+function defaultText(title: string, body: string): string {
+  if (!title && !body) return '';
+  if (!body) return title;
+  if (!title) return body;
+  return `${title}\n\n${body}`;
+}
+
+/**
+ * Build a draft sticky note attached to the anchor element box.
+ * Returns deterministic ids so the App layer can later locate the body for
+ * editing or removal without scanning by reviewId again.
+ */
+export function createStickyForAnchor(
+  anchor: AnchorBox,
+  options: CreateStickyOptions = {},
+): CreateStickyResult {
+  const reviewId = options.reviewId ?? ulid();
+  const stickyX = anchor.x + anchor.width + STICKY_OFFSET_X;
+  const stickyY = anchor.y + STICKY_OFFSET_Y;
+
+  const body: ReviewStickyCustomData = {
+    kind: STICKY_ELEMENT_KIND,
+    reviewId,
+    draft: true,
+    anchorElementId: anchor.id,
+    role: 'body',
+  };
+  const connector: ReviewStickyCustomData = {
+    kind: STICKY_ELEMENT_KIND,
+    reviewId,
+    draft: true,
+    anchorElementId: anchor.id,
+    role: 'connector',
+  };
+
+  const labelText = defaultText(options.title ?? '', options.body ?? '');
+
+  const skeletons: ExcalidrawElementSkeleton[] = [
+    {
+      type: 'rectangle',
+      id: bodyElementId(reviewId),
+      x: stickyX,
+      y: stickyY,
+      width: STICKY_WIDTH,
+      height: STICKY_HEIGHT,
+      backgroundColor: STICKY_BG,
+      strokeColor: STICKY_STROKE,
+      fillStyle: 'solid',
+      roundness: { type: 3 },
+      locked: false,
+      customData: body,
+      label: labelText
+        ? {
+            text: labelText,
+            fontSize: 14,
+            strokeColor: STICKY_STROKE,
+            textAlign: 'left',
+            verticalAlign: 'top',
+          }
+        : undefined,
+    },
+    {
+      type: 'arrow',
+      id: connectorElementId(reviewId),
+      x: 0,
+      y: 0,
+      strokeColor: CONNECTOR_STROKE,
+      strokeStyle: 'dashed',
+      locked: false,
+      customData: connector,
+      start: { id: anchor.id },
+      end: { id: bodyElementId(reviewId) },
+    },
+  ];
+
+  const built = convertToExcalidrawElements(skeletons, {
+    regenerateIds: false,
+  }) as unknown as ExcalidrawElement[];
+
+  // Stamp customData on bound label so it travels with the sticky.
+  const stubs = built.map((element) => stampStickyCustomData(element as unknown as ExcalidrawElementStub, reviewId, anchor.id));
+
+  return {
+    reviewId,
+    elements: stubs,
+    bodyElementId: bodyElementId(reviewId),
+    connectorElementId: connectorElementId(reviewId),
+  };
+}
+
+function stampStickyCustomData(
+  element: ExcalidrawElementStub,
+  reviewId: string,
+  anchorElementId: string,
+): ExcalidrawElementStub {
+  const existing = element.customData as ReviewStickyCustomData | undefined;
+  if (existing?.kind === STICKY_ELEMENT_KIND) return element;
+
+  // Bound label inside the sticky body inherits sticky tagging.
+  if (
+    element.type === 'text' &&
+    typeof element.containerId === 'string' &&
+    element.containerId === bodyElementId(reviewId)
+  ) {
+    return {
+      ...element,
+      customData: {
+        kind: STICKY_ELEMENT_KIND,
+        reviewId,
+        draft: true,
+        anchorElementId,
+        role: 'body',
+      } satisfies ReviewStickyCustomData,
+    };
+  }
+  return element;
+}
+
+export function isStickyElement(element: ExcalidrawElementStub): boolean {
+  return isReviewStickyCustomData(element.customData);
+}
+
+export function getStickyReviewId(element: ExcalidrawElementStub): string | undefined {
+  const data = element.customData;
+  if (!isReviewStickyCustomData(data)) return undefined;
+  return data.reviewId;
+}
+
+/**
+ * Mark every element belonging to a sticky group as committed (draft = false).
+ * Used by the save action.
+ */
+export function commitSticky(
+  elements: readonly ExcalidrawElementStub[],
+  reviewId: string,
+): ExcalidrawElementStub[] {
+  return elements.map((element) => {
+    const data = element.customData;
+    if (!isReviewStickyCustomData(data) || data.reviewId !== reviewId) return element;
+    return {
+      ...element,
+      customData: { ...data, draft: false } satisfies ReviewStickyCustomData,
+    };
+  });
+}
+
+/**
+ * Drop every element belonging to a sticky group. Used by cancel and delete.
+ */
+export function removeSticky(
+  elements: readonly ExcalidrawElementStub[],
+  reviewId: string,
+): ExcalidrawElementStub[] {
+  return elements.filter((element) => {
+    const data = element.customData;
+    return !isReviewStickyCustomData(data) || data.reviewId !== reviewId;
+  });
+}
+
+/**
+ * Update the rendered text on the sticky's bound label.
+ * If the label element does not exist (e.g. created without text and Excalidraw
+ * did not generate a label), this is a no-op; the App layer is expected to
+ * recreate the sticky in that case.
+ */
+export function updateStickyText(
+  elements: readonly ExcalidrawElementStub[],
+  reviewId: string,
+  title: string,
+  body: string,
+): ExcalidrawElementStub[] {
+  const text = defaultText(title, body);
+  return elements.map((element) => {
+    const data = element.customData;
+    if (!isReviewStickyCustomData(data) || data.reviewId !== reviewId) return element;
+    if (element.type !== 'text') return element;
+    return {
+      ...element,
+      text,
+      originalText: text,
+    };
+  });
+}
+
+export interface StickyGroup {
+  reviewId: string;
+  body?: ExcalidrawElementStub;
+  connector?: ExcalidrawElementStub;
+  label?: ExcalidrawElementStub;
+}
+
+export function listStickyGroups(elements: readonly ExcalidrawElementStub[]): StickyGroup[] {
+  const groups = new Map<string, StickyGroup>();
+  for (const element of elements) {
+    const data = element.customData;
+    if (!isReviewStickyCustomData(data)) continue;
+    const group = groups.get(data.reviewId) ?? { reviewId: data.reviewId };
+    if (data.role === 'body') {
+      if (element.type === 'rectangle') group.body = element;
+      else if (element.type === 'text') group.label = element;
+    } else if (data.role === 'connector') {
+      group.connector = element;
+    }
+    groups.set(data.reviewId, group);
+  }
+  return Array.from(groups.values());
+}

--- a/frontend/src/sticky/types.ts
+++ b/frontend/src/sticky/types.ts
@@ -1,0 +1,26 @@
+import { isNonEmptyString, isRecord } from '../types/utils';
+
+export const STICKY_ELEMENT_KIND = 'reviewSticky' as const;
+
+export interface ReviewStickyCustomData {
+  kind: typeof STICKY_ELEMENT_KIND;
+  /** ULID assigned at creation; stable across renames and re-renders. */
+  reviewId: string;
+  /** True while the sticky is being authored and not yet committed. */
+  draft?: boolean;
+  /** Element id of the anchor (auto-generated graph node) the sticky is attached to. */
+  anchorElementId?: string;
+  /**
+   * Distinguishes the sticky body element from its anchor connector.
+   * Both share the same reviewId so cancellation/save can clean them up together.
+   */
+  role: 'body' | 'connector';
+}
+
+export function isReviewStickyCustomData(value: unknown): value is ReviewStickyCustomData {
+  if (!isRecord(value)) return false;
+  if (value.kind !== STICKY_ELEMENT_KIND) return false;
+  if (!isNonEmptyString(value.reviewId)) return false;
+  if (value.role !== 'body' && value.role !== 'connector') return false;
+  return true;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@excalidraw/excalidraw": "^0.18.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
+        "ulid": "^3.0.2",
         "yjs": "^13.6.30"
       },
       "devDependencies": {
@@ -12484,6 +12485,15 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ulid": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/ulid/-/ulid-3.0.2.tgz",
+      "integrity": "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==",
+      "license": "MIT",
+      "bin": {
+        "ulid": "dist/cli.js"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
## Summary

PR #66 §C4의 "보조 1 — 포스트잇" 컨셉 구현. 사용자가 그래프 노드를 우클릭(또는 선택 후 툴바 버튼)해서 ULID 기반 리뷰 포스트잇을 부착하고 인라인으로 작성/저장/취소할 수 있게 합니다. PR #82가 develop에 도입한 컨텍스트 메뉴 attach 흐름 위에 sticky를 통합했습니다. §C5의 영속화(소스 주석 + .md 본문 round-trip)는 의식적으로 #71에서 처리.

## Changes

- `frontend/src/sticky/types.ts` 추가: `ReviewStickyCustomData` (`reviewId` ULID, `draft`, `anchorElementId`, `role: 'body' | 'connector'`). `kind`는 graph/types의 `REVIEW_STICKY_KIND`를 re-export해서 `userElements` 분류와 일원화
- `frontend/src/sticky/sticky.ts` 추가: `createStickyForAnchor` (`convertToExcalidrawElements({regenerateIds:false})`로 deterministic id), `commitSticky` / `removeSticky` / `updateStickyText` / `listStickyGroups`. 빈 텍스트 draft도 라벨 슬롯을 유지하도록 single-space placeholder 사용
- `frontend/src/App.tsx`: 컨텍스트 메뉴와 툴바에 "포스트잇 추가" 항목 추가, draft 인라인 에디터(제목/본문/저장/취소), `applyAnalysis`에서 sticky 보존
- `frontend/src/App.css`: sticky 인라인 에디터 스타일
- `frontend/package.json`: `ulid@3` 추가 (CSP 안전한 pure-function 패키지)
- 단위 테스트 15건 추가 (`frontend/src/sticky/sticky.test.ts`) — 생성/customData stamping/deterministic id/dashed connector binding/ULID 발급/commit·remove·update/그룹 listing/**빈 라벨에서도 updateStickyText 동작** (regression)

## Related Issue

Closes #70

## 설계 결정

- draft 영속화: `customData.draft = true` element 자체로만 표현. 별도 scratch store 없음 → `.codetrace` round-trip이 자동으로 보존
- attach 흐름: PR #82가 도입한 "노드 선택 → 컨텍스트 메뉴 → 메모 추가" 패턴을 재사용. sticky는 같은 메뉴에 "포스트잇 추가" 항목으로 들어감 (자체 모드 토글 없음)
- connector lifecycle: body/label/connector 모두 같은 `reviewId`를 공유, cancel/save/remove가 그룹 단위 동작
- kind 일원화: sticky/types.ts가 graph/types의 `REVIEW_STICKY_KIND`를 re-export하므로 `userElements`의 `isCodetraceElementKind`가 sticky를 managed element로 자동 인식 → `normalizeUserElements`가 sticky를 user-drawn 처리하지 않음

## Test plan

- [x] frontend jest 65건 통과 (sticky 15 + develop 50)
- [x] frontend `tsc --noEmit` 통과
- [x] frontend `vite build` 통과
- [ ] **Webview 실행 검증 미완료** — VS Code Extension Host (F5):
  1. 그래프 노드 선택 → 우클릭/툴바의 "포스트잇 추가" → 노드 옆에 포스트잇 + 점선 연결 부착
  2. 인라인 에디터에 제목/본문 입력 → 저장 → 라벨에 텍스트 반영, `customData.draft === false`
  3. 취소 → body/connector/label 모두 사라짐
  4. 저장 후 캔버스 닫고 다시 열기 → sticky 보존 (draft·committed 모두)
  5. 분석 재실행 → 기존 sticky 유지, 새 graph 노드만 dagre 배치
  6. 자동 노드 이동 시 connector binding이 따라오는지

## 알려진 위험

- 인라인 에디터 위치가 우상단 고정 — sticky 본체와 시각적으로 떨어져 있음. UX 검증 후 위치/연결 표시 개선 검토
- ULID는 `crypto.getRandomValues` 사용 → webview 정상 동작, 구식 환경 미보장 (대상 외)

## Out of scope

- 소스 주석 ↔ md 본문 round-trip → #71
- 노드 삭제 시 sticky 정리 → #72
