### PR TITLE
feat(frontend): 사용자 화살표/메모 도구 추가

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,99 @@
+.codetrace-canvas {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+.codetrace-canvas__controls {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 10;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.codetrace-canvas__button {
+  min-height: 30px;
+  padding: 6px 10px;
+  border: 1px solid #a3aab8;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #1f2937;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: 0 1px 2px rgb(15 23 42 / 12%);
+  cursor: pointer;
+}
+
+.codetrace-canvas__button:hover:not(:disabled) {
+  border-color: #2563eb;
+}
+
+.codetrace-canvas__button[data-active='true'] {
+  border-color: #2563eb;
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.codetrace-canvas__button:disabled {
+  color: #8a93a3;
+  background: #f3f5f8;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.codetrace-canvas__context-menu {
+  position: absolute;
+  z-index: 20;
+  min-width: 132px;
+  padding: 4px;
+  border: 1px solid #cbd1dc;
+  border-radius: 6px;
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgb(15 23 42 / 16%);
+}
+
+.codetrace-canvas__context-menu-item {
+  width: 100%;
+  min-height: 30px;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #1f2937;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.codetrace-canvas__context-menu-item:hover {
+  background: #eff6ff;
+  color: #1d4ed8;
+}
+
+.codetrace-canvas .excalidraw button[aria-label='Rectangle'],
+.codetrace-canvas .excalidraw button[aria-label='Diamond'],
+.codetrace-canvas .excalidraw button[aria-label='Ellipse'],
+.codetrace-canvas .excalidraw button[aria-label='Line'],
+.codetrace-canvas .excalidraw button[aria-label='Draw'],
+.codetrace-canvas .excalidraw button[aria-label='Eraser'],
+.codetrace-canvas .excalidraw button[aria-label='Frame tool'],
+.codetrace-canvas .excalidraw button[aria-label='Insert image'],
+.codetrace-canvas .excalidraw button[aria-label='Web Embed'],
+.codetrace-canvas .excalidraw button[aria-label='Laser pointer'],
+.codetrace-canvas .excalidraw button[title^='Rectangle'],
+.codetrace-canvas .excalidraw button[title^='Diamond'],
+.codetrace-canvas .excalidraw button[title^='Ellipse'],
+.codetrace-canvas .excalidraw button[title^='Line'],
+.codetrace-canvas .excalidraw button[title^='Draw'],
+.codetrace-canvas .excalidraw button[title^='Eraser'],
+.codetrace-canvas .excalidraw button[title^='Frame tool'],
+.codetrace-canvas .excalidraw button[title^='Insert image'],
+.codetrace-canvas .excalidraw button[title^='Web Embed'],
+.codetrace-canvas .excalidraw button[title^='Laser pointer'] {
+  display: none !important;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
-import { Excalidraw, CaptureUpdateAction } from '@excalidraw/excalidraw';
+import { CaptureUpdateAction, Excalidraw } from '@excalidraw/excalidraw';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, MouseEvent as ReactMouseEvent } from 'react';
 import type { ExcalidrawElement } from '@excalidraw/excalidraw/element/types';
 import type {
   AppState,
@@ -10,6 +10,13 @@ import type {
   ExcalidrawInitialDataState,
 } from '@excalidraw/excalidraw/types';
 import {
+  CODETRACE_EXCALIDRAW_UI_OPTIONS,
+  addMemoToGraphNode,
+  getSelectedGraphNode,
+  isCodeTraceAllowedTool,
+  normalizeUserElements,
+} from './annotations/userElements';
+import {
   createCanvasDocumentFromScene,
   parseCanvasDocumentContent,
   toExcalidrawInitialData,
@@ -18,6 +25,7 @@ import { serializeCanvasDocument, type ExcalidrawElementStub } from './types/Can
 import type { CodeCard } from './types/CodeCard';
 import {
   convertGraphToElements,
+  extractNodeGroupIds,
   extractPositions,
   partitionElements,
   setAutoElementsLocked,
@@ -30,8 +38,16 @@ import {
   subscribeAnalysisUpdates,
   subscribeDocumentUpdates,
 } from './vscodeBridge';
+import './App.css';
 
 type ExcalidrawChangeHandler = NonNullable<ComponentProps<typeof Excalidraw>['onChange']>;
+type ExcalidrawPointerDownHandler = NonNullable<ComponentProps<typeof Excalidraw>['onPointerDown']>;
+
+type NodeContextMenuState = {
+  nodeId: string;
+  x: number;
+  y: number;
+};
 
 function readInitialDocument() {
   return parseCanvasDocumentContent(getInitialDocumentContent() ?? '');
@@ -47,6 +63,8 @@ export default function App() {
   const latestContentRef = useRef<string>(initialContent);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [autoLocked, setAutoLocked] = useState(true);
+  const [selectedGraphNodeId, setSelectedGraphNodeId] = useState<string | null>(null);
+  const [nodeContextMenu, setNodeContextMenu] = useState<NodeContextMenuState | null>(null);
 
   useEffect(() => {
     cardsRef.current = initialDocument.cards;
@@ -98,12 +116,13 @@ export default function App() {
       const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
       const { user } = partitionElements(current);
       const existingPositions = extractPositions(current);
+      const existingNodeGroupIds = extractNodeGroupIds(current);
 
       const { elements: autoElements } = convertGraphToElements(
         payload.nodes,
         payload.edges,
         existingPositions,
-        { locked: autoLocked },
+        { locked: autoLocked, nodeGroupIds: existingNodeGroupIds },
       );
 
       const next = [...autoElements, ...user];
@@ -139,8 +158,20 @@ export default function App() {
 
   const handleChange = useCallback<ExcalidrawChangeHandler>(
     (elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {
+      const normalized = normalizeUserElements(elements as unknown as ExcalidrawElementStub[]);
+      const sceneElements = normalized.elements;
+
+      setSelectedGraphNodeId(getSelectedGraphNode(sceneElements, appState.selectedElementIds)?.id ?? null);
+
+      if (normalized.changed) {
+        apiRef.current?.updateScene({
+          elements: sceneElements as unknown as ExcalidrawElement[],
+          captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+      }
+
       const document = createCanvasDocumentFromScene({
-        elements: elements as unknown as ExcalidrawElementStub[],
+        elements: sceneElements as unknown as ExcalidrawElementStub[],
         appState: appState as unknown as Record<string, unknown>,
         files: files as unknown as Record<string, unknown>,
         cards: cardsRef.current,
@@ -155,31 +186,107 @@ export default function App() {
     [],
   );
 
+  const handlePointerDown = useCallback<ExcalidrawPointerDownHandler>((activeTool) => {
+    setNodeContextMenu(null);
+    if (isCodeTraceAllowedTool(activeTool.type)) return;
+    apiRef.current?.setActiveTool({ type: 'selection' });
+  }, []);
+
+  const addMemo = useCallback((nodeElementId?: string) => {
+    const api = apiRef.current;
+    if (!api) return;
+
+    const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+    const selectedNode = nodeElementId
+      ? current.find((element) => element.id === nodeElementId)
+      : getSelectedGraphNode(current, api.getAppState().selectedElementIds);
+    const selectedNodeId = selectedNode?.id;
+    if (!selectedNodeId) return;
+
+    const result = addMemoToGraphNode(current, selectedNodeId);
+    if (!result) return;
+
+    api.updateScene({
+      elements: result.elements as unknown as ExcalidrawElement[],
+      appState: {
+        selectedElementIds: {
+          [selectedNodeId]: true,
+          [result.memoId]: true,
+        },
+      },
+      captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+    });
+    setSelectedGraphNodeId(selectedNodeId);
+    setNodeContextMenu(null);
+  }, []);
+
+  const handleAddMemo = useCallback(() => {
+    addMemo();
+  }, [addMemo]);
+
+  const handleContextMenu = useCallback((event: ReactMouseEvent<HTMLDivElement>) => {
+    const api = apiRef.current;
+    const container = containerRef.current;
+    if (!api || !container) return;
+
+    const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+    const selectedNode = getSelectedGraphNode(current, api.getAppState().selectedElementIds);
+    if (!selectedNode) return;
+
+    event.preventDefault();
+    const bounds = container.getBoundingClientRect();
+    setNodeContextMenu({
+      nodeId: selectedNode.id,
+      x: event.clientX - bounds.left,
+      y: event.clientY - bounds.top,
+    });
+  }, []);
+
   return (
-    <div ref={containerRef} style={{ width: '100%', height: '100%', position: 'relative' }}>
-      <button
-        type="button"
-        onClick={toggleAutoLock}
-        style={{
-          position: 'absolute',
-          top: 12,
-          right: 12,
-          zIndex: 10,
-          padding: '6px 10px',
-          fontSize: 12,
-          background: autoLocked ? '#eef2ff' : '#fef3c7',
-          border: '1px solid #4f46e5',
-          borderRadius: 6,
-          cursor: 'pointer',
-        }}
-        title="자동 생성 노드의 잠금을 토글합니다"
-      >
-        {autoLocked ? '자동 노드 잠금' : '자동 노드 해제'}
-      </button>
+    <div ref={containerRef} className="codetrace-canvas" onContextMenu={handleContextMenu}>
+      <div className="codetrace-canvas__controls" aria-label="CodeTrace canvas controls">
+        <button
+          type="button"
+          className="codetrace-canvas__button"
+          data-active={autoLocked}
+          onClick={toggleAutoLock}
+          title="자동 생성 노드의 잠금을 토글합니다"
+        >
+          {autoLocked ? '자동 노드 잠금' : '자동 노드 해제'}
+        </button>
+        <button
+          type="button"
+          className="codetrace-canvas__button"
+          onClick={handleAddMemo}
+          disabled={!selectedGraphNodeId}
+          title="선택한 그래프 노드에 텍스트 메모를 추가합니다"
+        >
+          메모 추가
+        </button>
+      </div>
+      {nodeContextMenu ? (
+        <div
+          className="codetrace-canvas__context-menu"
+          style={{ left: nodeContextMenu.x, top: nodeContextMenu.y }}
+          role="menu"
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          <button
+            type="button"
+            role="menuitem"
+            className="codetrace-canvas__context-menu-item"
+            onClick={() => addMemo(nodeContextMenu.nodeId)}
+          >
+            메모 추가
+          </button>
+        </div>
+      ) : null}
       <Excalidraw
         excalidrawAPI={handleExcalidrawAPI}
         initialData={initialData as unknown as ExcalidrawInitialDataState}
         onChange={handleChange}
+        onPointerDown={handlePointerDown}
+        UIOptions={CODETRACE_EXCALIDRAW_UI_OPTIONS}
       />
     </div>
   );

--- a/frontend/src/annotations/userElements.test.ts
+++ b/frontend/src/annotations/userElements.test.ts
@@ -1,0 +1,185 @@
+jest.mock('@excalidraw/excalidraw', () => ({
+  convertToExcalidrawElements: (skeletons: Array<Record<string, unknown>>) =>
+    skeletons.map((skeleton) => ({
+      ...skeleton,
+      width: skeleton.width ?? 120,
+      height: skeleton.height ?? 32,
+    })),
+}));
+
+import {
+  addMemoToGraphNode,
+  getSelectedGraphNode,
+  isCodeTraceAllowedTool,
+  normalizeUserElements,
+} from './userElements';
+import type { ExcalidrawElementStub } from '../types/CanvasDocument';
+import {
+  GRAPH_ELEMENT_KIND_EDGE,
+  GRAPH_ELEMENT_KIND_NODE,
+  USER_ELEMENT_KIND_ARROW,
+  USER_ELEMENT_KIND_TEXT,
+} from '../graph/types';
+
+describe('normalizeUserElements', () => {
+  it('marks user arrows while preserving Excalidraw bindings', () => {
+    const elements: ExcalidrawElementStub[] = [
+      {
+        id: 'arrow-1',
+        type: 'arrow',
+        startBinding: { elementId: 'auto-node-a', focus: 0, gap: 4 },
+        endBinding: { elementId: 'auto-node-b', focus: 0, gap: 4 },
+      },
+    ];
+
+    const result = normalizeUserElements(elements);
+    const arrow = result.elements[0];
+
+    expect(result.changed).toBe(true);
+    expect(arrow.customData).toMatchObject({
+      kind: USER_ELEMENT_KIND_ARROW,
+      label: 'user-drawn',
+      source: 'user',
+    });
+    expect(arrow.startBinding).toEqual(elements[0].startBinding);
+    expect(arrow.endBinding).toEqual(elements[0].endBinding);
+    expect(arrow.strokeWidth).toBe(3);
+    expect(arrow.strokeStyle).toBe('dashed');
+  });
+
+  it('marks user text separately from auto graph labels', () => {
+    const elements: ExcalidrawElementStub[] = [
+      { id: 'text-1', type: 'text', text: 'note' },
+      {
+        id: 'label-1',
+        type: 'text',
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, source: 'auto' },
+      },
+    ];
+
+    const result = normalizeUserElements(elements);
+
+    expect(result.elements[0].customData).toMatchObject({
+      kind: USER_ELEMENT_KIND_TEXT,
+      source: 'user',
+    });
+    expect(result.elements[1]).toBe(elements[1]);
+  });
+
+  it('does not rewrite managed graph edges', () => {
+    const edge: ExcalidrawElementStub = {
+      id: 'auto-edge-a-b',
+      type: 'arrow',
+      customData: { kind: GRAPH_ELEMENT_KIND_EDGE, source: 'auto' },
+    };
+
+    const result = normalizeUserElements([edge]);
+
+    expect(result.changed).toBe(false);
+    expect(result.elements[0]).toBe(edge);
+  });
+});
+
+describe('addMemoToGraphNode', () => {
+  it('adds a user text memo to the same group as the selected node', () => {
+    const elements: ExcalidrawElementStub[] = [
+      {
+        id: 'auto-node-a',
+        type: 'rectangle',
+        x: 10,
+        y: 20,
+        width: 180,
+        height: 64,
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId: 'a', source: 'auto' },
+      },
+      {
+        id: 'auto-node-a-label',
+        type: 'text',
+        containerId: 'auto-node-a',
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId: 'a', source: 'auto' },
+      },
+    ];
+
+    const result = addMemoToGraphNode(elements, 'auto-node-a', {
+      groupId: 'node-note-a',
+      id: 'memo-a',
+      text: 'memo text',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.groupId).toBe('node-note-a');
+
+    const node = result?.elements.find((element) => element.id === 'auto-node-a');
+    const label = result?.elements.find((element) => element.id === 'auto-node-a-label');
+    const memo = result?.elements.find((element) => element.id === 'memo-a');
+
+    expect(node?.groupIds).toEqual(['node-note-a']);
+    expect(label?.groupIds).toEqual(['node-note-a']);
+    expect(memo?.groupIds).toEqual(['node-note-a']);
+    expect(memo?.customData).toMatchObject({
+      kind: USER_ELEMENT_KIND_TEXT,
+      source: 'user',
+      anchoredTo: 'auto-node-a',
+    });
+  });
+
+  it('keeps memo and node movement in sync through shared groupIds', () => {
+    const result = addMemoToGraphNode(
+      [
+        {
+          id: 'auto-node-a',
+          type: 'rectangle',
+          x: 10,
+          y: 20,
+          width: 180,
+          customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId: 'a', source: 'auto' },
+        },
+      ],
+      'auto-node-a',
+      { groupId: 'node-note-a', id: 'memo-a' },
+    );
+    expect(result).not.toBeNull();
+
+    const moved = result!.elements.map((element) =>
+      Array.isArray(element.groupIds) && element.groupIds.includes('node-note-a')
+        ? {
+            ...element,
+            x: Number(element.x ?? 0) + 30,
+            y: Number(element.y ?? 0) + 10,
+          }
+        : element,
+    );
+
+    expect(moved.find((element) => element.id === 'auto-node-a')).toMatchObject({ x: 40, y: 30 });
+    expect(moved.find((element) => element.id === 'memo-a')).toMatchObject({ x: 244, y: 38 });
+  });
+
+  it('resolves a graph node from a selected bound label', () => {
+    const node: ExcalidrawElementStub = {
+      id: 'auto-node-a',
+      type: 'rectangle',
+      customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId: 'a', source: 'auto' },
+    };
+    const label: ExcalidrawElementStub = {
+      id: 'label-a',
+      type: 'text',
+      containerId: 'auto-node-a',
+    };
+
+    expect(getSelectedGraphNode([node, label], { 'label-a': true })).toBe(node);
+  });
+});
+
+describe('isCodeTraceAllowedTool', () => {
+  it('allows the curated canvas tools and rejects shape/freehand tools', () => {
+    expect(isCodeTraceAllowedTool('selection')).toBe(true);
+    expect(isCodeTraceAllowedTool('hand')).toBe(true);
+    expect(isCodeTraceAllowedTool('arrow')).toBe(true);
+    expect(isCodeTraceAllowedTool('text')).toBe(true);
+
+    expect(isCodeTraceAllowedTool('rectangle')).toBe(false);
+    expect(isCodeTraceAllowedTool('ellipse')).toBe(false);
+    expect(isCodeTraceAllowedTool('freedraw')).toBe(false);
+    expect(isCodeTraceAllowedTool('eraser')).toBe(false);
+  });
+});

--- a/frontend/src/annotations/userElements.ts
+++ b/frontend/src/annotations/userElements.ts
@@ -1,0 +1,256 @@
+import { convertToExcalidrawElements } from '@excalidraw/excalidraw';
+import type { ExcalidrawElementSkeleton } from '@excalidraw/excalidraw/data/transform';
+
+import {
+  GRAPH_ELEMENT_KIND_EDGE,
+  GRAPH_ELEMENT_KIND_NODE,
+  REVIEW_STICKY_KIND,
+  USER_ELEMENT_KIND_ARROW,
+  USER_ELEMENT_KIND_TEXT,
+  type CodetraceElementKind,
+} from '../graph/types';
+import type { ExcalidrawElementStub } from '../types/CanvasDocument';
+import { isRecord } from '../types/utils';
+
+const USER_ARROW_STROKE = '#d6336c';
+const USER_TEXT_STROKE = '#0f766e';
+const USER_ELEMENT_SOURCE = 'user';
+const DEFAULT_MEMO_TEXT = 'Memo';
+const MEMO_OFFSET_X = 24;
+const MEMO_OFFSET_Y = 8;
+
+export const CODETRACE_ALLOWED_TOOL_TYPES = new Set(['selection', 'hand', 'arrow', 'text']);
+
+export const CODETRACE_EXCALIDRAW_UI_OPTIONS = {
+  canvasActions: {
+    changeViewBackgroundColor: false,
+    clearCanvas: false,
+    export: false,
+    loadScene: false,
+    saveAsImage: false,
+    saveToActiveFile: false,
+    toggleTheme: null,
+  },
+  tools: {
+    image: false,
+  },
+} as const;
+
+export type SelectedElementIds = Record<string, boolean>;
+
+export type NormalizeUserElementsResult = {
+  elements: readonly ExcalidrawElementStub[];
+  changed: boolean;
+};
+
+export type AddNodeMemoOptions = {
+  groupId?: string;
+  id?: string;
+  text?: string;
+};
+
+export type AddNodeMemoResult = {
+  elements: ExcalidrawElementStub[];
+  groupId: string;
+  memoId: string;
+};
+
+export function isCodeTraceAllowedTool(toolType: unknown): boolean {
+  return typeof toolType === 'string' && CODETRACE_ALLOWED_TOOL_TYPES.has(toolType);
+}
+
+export function normalizeUserElements(
+  elements: readonly ExcalidrawElementStub[],
+): NormalizeUserElementsResult {
+  let changed = false;
+  const next = elements.map((element) => {
+    const normalized = normalizeUserElement(element);
+    changed ||= normalized !== element;
+    return normalized;
+  });
+
+  return {
+    elements: changed ? next : elements,
+    changed,
+  };
+}
+
+export function getSelectedGraphNode(
+  elements: readonly ExcalidrawElementStub[],
+  selectedElementIds: unknown,
+): ExcalidrawElementStub | undefined {
+  const selectedIds = normalizeSelectedElementIds(selectedElementIds);
+  const selected = elements.filter((element) => selectedIds[element.id]);
+
+  for (const element of selected) {
+    if (isGraphNodeElement(element)) return element;
+  }
+
+  for (const element of selected) {
+    if (typeof element.containerId !== 'string') continue;
+    const container = elements.find((candidate) => candidate.id === element.containerId);
+    if (container && isGraphNodeElement(container)) return container;
+  }
+
+  return undefined;
+}
+
+export function addMemoToGraphNode(
+  elements: readonly ExcalidrawElementStub[],
+  nodeElementId: string,
+  options: AddNodeMemoOptions = {},
+): AddNodeMemoResult | null {
+  const node = elements.find((element) => element.id === nodeElementId);
+  if (!node || !isGraphNodeElement(node)) return null;
+
+  const groupIds = getElementGroupIds(node);
+  const groupId = options.groupId ?? groupIds[0] ?? `node-note-${node.id}`;
+  const nextGroupIds = groupIds.includes(groupId) ? groupIds : [groupId, ...groupIds];
+  const memoId = options.id ?? createElementId('user-text');
+  const memo = createMemoElement(node, nextGroupIds, memoId, options.text ?? DEFAULT_MEMO_TEXT);
+
+  const updatedElements = elements.map((element) =>
+    isNodeOrBoundLabel(element, node.id) ? withGroupIds(element, nextGroupIds) : element,
+  );
+
+  return {
+    elements: [...updatedElements, memo],
+    groupId,
+    memoId,
+  };
+}
+
+export function getElementKind(element: ExcalidrawElementStub): CodetraceElementKind | undefined {
+  const data = getCustomData(element);
+  const kind = data.kind;
+  return isCodetraceElementKind(kind) ? kind : undefined;
+}
+
+function normalizeUserElement(element: ExcalidrawElementStub): ExcalidrawElementStub {
+  if (isManagedElement(element)) return element;
+
+  if (element.type === 'arrow') {
+    return {
+      ...element,
+      strokeColor: USER_ARROW_STROKE,
+      strokeWidth: 3,
+      strokeStyle: 'dashed',
+      endArrowhead: element.endArrowhead ?? 'arrow',
+      customData: {
+        ...getCustomData(element),
+        kind: USER_ELEMENT_KIND_ARROW,
+        label: 'user-drawn',
+        source: USER_ELEMENT_SOURCE,
+      },
+    };
+  }
+
+  if (element.type === 'text') {
+    return {
+      ...element,
+      strokeColor: USER_TEXT_STROKE,
+      customData: {
+        ...getCustomData(element),
+        kind: USER_ELEMENT_KIND_TEXT,
+        source: USER_ELEMENT_SOURCE,
+      },
+    };
+  }
+
+  return element;
+}
+
+function createMemoElement(
+  node: ExcalidrawElementStub,
+  groupIds: readonly string[],
+  memoId: string,
+  text: string,
+): ExcalidrawElementStub {
+  const skeleton: ExcalidrawElementSkeleton = {
+    type: 'text',
+    id: memoId,
+    x: asNumber(node.x) + asNumber(node.width) + MEMO_OFFSET_X,
+    y: asNumber(node.y) + MEMO_OFFSET_Y,
+    text,
+    fontSize: 16,
+    strokeColor: USER_TEXT_STROKE,
+    groupIds: [...groupIds],
+    customData: {
+      kind: USER_ELEMENT_KIND_TEXT,
+      source: USER_ELEMENT_SOURCE,
+      anchoredTo: node.id,
+    },
+  };
+  const [memo] = convertToExcalidrawElements([skeleton], {
+    regenerateIds: false,
+  }) as unknown as ExcalidrawElementStub[];
+
+  return memo ?? (skeleton as ExcalidrawElementStub);
+}
+
+function getCustomData(element: ExcalidrawElementStub): Record<string, unknown> {
+  return isRecord(element.customData) ? element.customData : {};
+}
+
+function isManagedElement(element: ExcalidrawElementStub): boolean {
+  return getElementKind(element) !== undefined;
+}
+
+function isGraphNodeElement(element: ExcalidrawElementStub): boolean {
+  return getElementKind(element) === GRAPH_ELEMENT_KIND_NODE;
+}
+
+function isNodeOrBoundLabel(element: ExcalidrawElementStub, nodeElementId: string): boolean {
+  return element.id === nodeElementId || element.containerId === nodeElementId;
+}
+
+function withGroupIds(
+  element: ExcalidrawElementStub,
+  groupIds: readonly string[],
+): ExcalidrawElementStub {
+  if (arraysEqual(getElementGroupIds(element), groupIds)) return element;
+  return {
+    ...element,
+    groupIds: [...groupIds],
+  };
+}
+
+function getElementGroupIds(element: ExcalidrawElementStub): string[] {
+  return Array.isArray(element.groupIds)
+    ? element.groupIds.filter((groupId): groupId is string => typeof groupId === 'string')
+    : [];
+}
+
+function normalizeSelectedElementIds(value: unknown): SelectedElementIds {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, boolean] => typeof entry[0] === 'string' && entry[1] === true,
+    ),
+  );
+}
+
+function isCodetraceElementKind(value: unknown): value is CodetraceElementKind {
+  return (
+    value === GRAPH_ELEMENT_KIND_NODE ||
+    value === GRAPH_ELEMENT_KIND_EDGE ||
+    value === REVIEW_STICKY_KIND ||
+    value === USER_ELEMENT_KIND_ARROW ||
+    value === USER_ELEMENT_KIND_TEXT
+  );
+}
+
+function arraysEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function asNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function createElementId(prefix: string): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return `${prefix}-${crypto.randomUUID()}`;
+  }
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}

--- a/frontend/src/graph/converter.test.ts
+++ b/frontend/src/graph/converter.test.ts
@@ -85,6 +85,7 @@ beforeEach(() => {
 
 import {
   convertGraphToElements,
+  extractNodeGroupIds,
   extractPositions,
   isAutoElement,
   partitionElements,
@@ -206,6 +207,17 @@ describe('convertGraphToElements', () => {
     expect(user).toHaveLength(0);
     expect(auto.length).toBe(first.length);
   });
+
+  it('preserves node groupIds on regenerated nodes and bound labels', () => {
+    const { elements } = convertGraphToElements(sampleNodes, sampleEdges, new Map(), {
+      nodeGroupIds: new Map([['a', ['node-note-a']]]),
+    });
+    const node = elements.find((e) => e.id === 'auto-node-a');
+    const label = elements.find((e) => e.containerId === 'auto-node-a');
+
+    expect(node?.groupIds).toEqual(['node-note-a']);
+    expect(label?.groupIds).toEqual(['node-note-a']);
+  });
 });
 
 describe('extractPositions', () => {
@@ -228,6 +240,28 @@ describe('extractPositions', () => {
     const positions = extractPositions(elements);
     expect(positions.get('a')).toEqual({ x: 10, y: 20 });
     expect(positions.size).toBe(1);
+  });
+});
+
+describe('extractNodeGroupIds', () => {
+  it('reads groupIds from auto graphNode rectangles', () => {
+    const elements: ExcalidrawElementStub[] = [
+      {
+        id: 'auto-node-a',
+        type: 'rectangle',
+        groupIds: ['node-note-a'],
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId: 'a', source: 'auto' },
+      },
+      {
+        id: 'auto-node-a-label',
+        type: 'text',
+        groupIds: ['node-note-a'],
+        containerId: 'auto-node-a',
+        customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId: 'a', source: 'auto' },
+      },
+    ];
+
+    expect(extractNodeGroupIds(elements).get('a')).toEqual(['node-note-a']);
   });
 });
 

--- a/frontend/src/graph/converter.ts
+++ b/frontend/src/graph/converter.ts
@@ -19,6 +19,7 @@ const AUTO_EDGE_STROKE = '#4f46e5';
 
 export interface ConvertOptions {
   locked?: boolean;
+  nodeGroupIds?: ReadonlyMap<string, readonly string[]>;
 }
 
 export interface ConvertResult {
@@ -72,6 +73,7 @@ export function convertGraphToElements(
       y: pos.y,
       width: NODE_WIDTH,
       height: NODE_HEIGHT,
+      groupIds: [...(options.nodeGroupIds?.get(node.id) ?? [])],
       strokeColor: AUTO_NODE_STROKE,
       backgroundColor: AUTO_NODE_BG,
       fillStyle: 'solid',
@@ -117,12 +119,17 @@ export function convertGraphToElements(
 
   // Stamp customData on auto-generated bound labels so partitionElements()
   // and the lock toggle treat them as auto elements.
-  const stubs = built.map((element) => stampAutoCustomData(element as unknown as ExcalidrawElementStub));
+  const stubs = built.map((element) =>
+    stampAutoCustomData(element as unknown as ExcalidrawElementStub, built as unknown as ExcalidrawElementStub[]),
+  );
 
   return { elements: stubs, positions: merged };
 }
 
-function stampAutoCustomData(element: ExcalidrawElementStub): ExcalidrawElementStub {
+function stampAutoCustomData(
+  element: ExcalidrawElementStub,
+  elements: readonly ExcalidrawElementStub[],
+): ExcalidrawElementStub {
   const existing = element.customData as GraphCustomData | undefined;
   if (existing?.source === 'auto') return element;
 
@@ -131,8 +138,16 @@ function stampAutoCustomData(element: ExcalidrawElementStub): ExcalidrawElementS
     const containerId = element.containerId;
     if (containerId.startsWith('auto-node-')) {
       const nodeId = containerId.replace(/^auto-node-/, '');
+      const container = elements.find((candidate) => candidate.id === containerId);
+      const groupIds =
+        Array.isArray(element.groupIds) && element.groupIds.length > 0
+          ? element.groupIds
+          : Array.isArray(container?.groupIds)
+            ? container.groupIds
+            : [];
       return {
         ...element,
+        groupIds,
         customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId, source: 'auto' },
       };
     }
@@ -161,6 +176,21 @@ export function extractPositions(
     positions.set(nodeId, { x, y });
   }
   return positions;
+}
+
+export function extractNodeGroupIds(
+  elements: readonly ExcalidrawElementStub[],
+): Map<string, readonly string[]> {
+  const groupIds = new Map<string, readonly string[]>();
+  for (const element of elements) {
+    if (element.type !== 'rectangle') continue;
+    const data = element.customData as GraphCustomData | undefined;
+    if (data?.kind !== GRAPH_ELEMENT_KIND_NODE) continue;
+    if (typeof data.nodeId !== 'string') continue;
+    if (!Array.isArray(element.groupIds) || element.groupIds.length === 0) continue;
+    groupIds.set(data.nodeId, [...element.groupIds]);
+  }
+  return groupIds;
 }
 
 export function partitionElements(

--- a/frontend/src/graph/types.ts
+++ b/frontend/src/graph/types.ts
@@ -30,10 +30,22 @@ export interface CallGraphPayload {
 
 export const GRAPH_ELEMENT_KIND_NODE = 'graphNode' as const;
 export const GRAPH_ELEMENT_KIND_EDGE = 'graphEdge' as const;
+export const USER_ELEMENT_KIND_ARROW = 'userArrow' as const;
+export const USER_ELEMENT_KIND_TEXT = 'userText' as const;
+export const REVIEW_STICKY_KIND = 'reviewSticky' as const;
 
 export type GraphElementKind =
   | typeof GRAPH_ELEMENT_KIND_NODE
   | typeof GRAPH_ELEMENT_KIND_EDGE;
+
+export type UserElementKind =
+  | typeof USER_ELEMENT_KIND_ARROW
+  | typeof USER_ELEMENT_KIND_TEXT;
+
+export type CodetraceElementKind =
+  | GraphElementKind
+  | UserElementKind
+  | typeof REVIEW_STICKY_KIND;
 
 export interface GraphCustomData {
   kind: GraphElementKind;


### PR DESCRIPTION
## Summary
- 사용자 화살표/텍스트 요소를 customData.kind로 정규화하고 자동 그래프 엣지와 스타일을 구분했습니다.
- 선택 노드 메모 추가 버튼/컨텍스트 메뉴를 추가하고 노드/라벨/메모 groupIds를 공유하도록 했습니다.
- 자동 그래프 재분석 시 노드 groupIds를 보존해 메모 이동 동기화를 유지합니다.

## Tests
- npm.cmd test --workspace=frontend -- --runInBand
- npm.cmd run build --workspace=frontend

Closes #73