### PR TITLE
fix(ci): Claude 자동 리뷰가 항상 PR 코멘트를 남기도록

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -41,7 +41,17 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            추가 지시: blocking 이슈가 없더라도 항상 PR에 한국어 리뷰 코멘트를 남겨라.
+            코멘트에는 다음을 포함한다:
+              - 한 줄 변경 요약
+              - 잘 된 점 (있다면)
+              - 우려되는 점 / 후속에서 챙기면 좋은 점 (있다면)
+              - 검증 결과 (테스트/빌드 통과 여부, 직접 실행한 검증 항목)
+            blocking 이슈가 있으면 별도의 review (CHANGES_REQUESTED) 로 남기고,
+            없으면 일반 issue comment 로 남겨라.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

`claude-code-review.yml`이 PR을 분석하더라도 별도의 코멘트를 남기지 않아 status check만 SUCCESS로 마크되고 끝나는 문제를 고친다. blocking 이슈가 없어도 한국어 요약 코멘트를 남기도록 prompt를 확장하고, 코멘트 게시 권한을 부여한다.

## Changes

- `.github/workflows/claude-code-review.yml`: prompt에 코멘트 형식과 "이슈가 없어도 항상 코멘트" 지시 추가, `pull-requests` 권한을 `read` → `write`로 상향

## Related Issue

Closes #83

## Test plan

- [x] YAML 들여쓰기/문자열 형식 점검 (multiline `|` 블록)
- [ ] 머지 후 다음 PR이 열릴 때 Claude가 PR에 한국어 코멘트(한 줄 요약/잘 된 점/우려/검증 결과)를 게시하는지 확인
- [ ] 다음 PR에 blocking 이슈가 있을 경우 review가 CHANGES_REQUESTED 형태로 들어오는지 확인
