### PR TITLE
chore: sync main into develop (Claude review always-comment)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -41,7 +41,17 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: |
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            추가 지시: blocking 이슈가 없더라도 항상 PR에 한국어 리뷰 코멘트를 남겨라.
+            코멘트에는 다음을 포함한다:
+              - 한 줄 변경 요약
+              - 잘 된 점 (있다면)
+              - 우려되는 점 / 후속에서 챙기면 좋은 점 (있다면)
+              - 검증 결과 (테스트/빌드 통과 여부, 직접 실행한 검증 항목)
+            blocking 이슈가 있으면 별도의 review (CHANGES_REQUESTED) 로 남기고,
+            없으면 일반 issue comment 로 남겨라.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

PR #84(`fix(ci): Claude 자동 리뷰가 항상 PR 코멘트를 남기도록`)가 main에만 머지되어 develop의 워크플로가 옛 버전인 상태입니다. main → develop 동기화로 develop 기반 PR에서도 Claude 자동 리뷰 코멘트가 작동하도록 합니다.

## Changes

- `.github/workflows/claude-code-review.yml` (main에서 가져옴): prompt에 "blocking 이슈가 없어도 항상 한국어 코멘트" 지시 추가, `pull-requests` 권한 `read` → `write` 상향

## Related Issue

없음 (브랜치 동기화)

## 배경

워크플로는 main이 source of truth이고 PR #84로 main에 직접 적용되었음. develop에 동일한 변경이 들어와야 develop 기반의 PR(#81 등)에서도 Claude가 자동 코멘트를 남김.

## Test plan

- [x] merge 시 .gitignore 등 충돌 없음 (워크플로 한 파일만 변경됨)
- [ ] 머지 후 develop 기반 다음 PR push에서 Claude가 한국어 코멘트를 게시하는지 확인
