### PR TITLE
feat(extension): 변경 함수 노드 강조

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -48,7 +48,17 @@
         "extensions": [".codetrace"],
         "aliases": ["CodeTrace Canvas"]
       }
-    ]
+    ],
+    "configuration": {
+      "title": "CodeTrace",
+      "properties": {
+        "codetrace.git.baseBranch": {
+          "type": "string",
+          "default": "main",
+          "description": "Base branch or ref used to highlight changed function nodes in the CodeTrace graph."
+        }
+      }
+    }
   },
   "scripts": {
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --platform=node --format=cjs",

--- a/extension/src/analyzer/types.ts
+++ b/extension/src/analyzer/types.ts
@@ -15,6 +15,7 @@ export interface FunctionNode {
   kind: FunctionKind;
   file: string;
   range: SourceRange;
+  changedSinceBase?: boolean;
 }
 
 export interface CallEdge {
@@ -30,6 +31,8 @@ export interface CallGraph {
     engine: string;
     language: string;
     precision: PrecisionTier;
+    gitBaseRef?: string;
+    changedNodeCount?: number;
     warnings?: string[];
   };
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 import { extractWorkspaceCallGraph } from './analyzer/callGraph';
 import { CanvasEditorProvider } from './CanvasEditorProvider';
 import { CodeAnalyzer } from './CodeAnalyzer';
+import { markChangedFunctions } from './git/changedRanges';
+import { collectChangedLineRanges, getConfiguredGitBaseBranch } from './git/vscodeGit';
 
 
 export function activate(context: vscode.ExtensionContext) {
@@ -69,10 +71,30 @@ export function activate(context: vscode.ExtensionContext) {
         cancellable: true
       }, async (progress, token) => {
         progress.report({ message: 'Initializing hybrid analyzer...' });
-        return await extractWorkspaceCallGraph(rootPath, {
+        const graph = await extractWorkspaceCallGraph(rootPath, {
           searchParentTsconfig: true,
           limitToFiles
         });
+        progress.report({ message: 'Checking Git changes...' });
+        const baseRef = getConfiguredGitBaseBranch();
+        const changes = await collectChangedLineRanges(rootPath, baseRef);
+        const nodes = markChangedFunctions(graph.nodes, changes.ranges);
+        const changedNodeCount = nodes.filter(node => node.changedSinceBase).length;
+
+        return {
+          ...graph,
+          nodes,
+          metadata: {
+            engine: graph.metadata?.engine ?? 'Unknown',
+            language: graph.metadata?.language ?? 'Unknown',
+            precision: graph.metadata?.precision ?? 'standard',
+            gitBaseRef: changes.baseRef,
+            changedNodeCount,
+            warnings: changes.unavailableReason
+              ? [...(graph.metadata?.warnings ?? []), changes.unavailableReason]
+              : graph.metadata?.warnings,
+          },
+        };
       });
 
       if (!result) return;
@@ -84,6 +106,12 @@ export function activate(context: vscode.ExtensionContext) {
 
       outputChannel.appendLine(`Analysis complete using ${result.metadata?.engine} (${result.metadata?.precision})!`);
       outputChannel.appendLine(`Found ${result.nodes.length} nodes and ${result.edges.length} edges.`);
+      outputChannel.appendLine(
+        `Changed nodes vs ${result.metadata?.gitBaseRef ?? getConfiguredGitBaseBranch()}: ${result.metadata?.changedNodeCount ?? 0}.`,
+      );
+      for (const warning of result.metadata?.warnings ?? []) {
+        outputChannel.appendLine(`Warning: ${warning}`);
+      }
       
       const dir = vscode.Uri.joinPath(workspaceFolders[0].uri, '.codetrace');
       await vscode.workspace.fs.createDirectory(dir);

--- a/extension/src/git/changedRanges.test.ts
+++ b/extension/src/git/changedRanges.test.ts
@@ -1,0 +1,83 @@
+import * as path from 'path';
+import {
+  markChangedFunctions,
+  parseUnifiedDiffChangedRanges,
+} from './changedRanges';
+import type { FunctionNode } from '../analyzer/types';
+
+describe('parseUnifiedDiffChangedRanges', () => {
+  it('collects changed new-file line ranges from unified diff hunks', () => {
+    const workspaceRoot = path.resolve('/repo');
+    const file = path.resolve(workspaceRoot, 'src/sample.ts');
+    const diff = [
+      'diff --git a/src/sample.ts b/src/sample.ts',
+      'index 1111111..2222222 100644',
+      '--- a/src/sample.ts',
+      '+++ b/src/sample.ts',
+      '@@ -2,8 +2,9 @@ export function greet(name: string) {',
+      '   const upper = name.toUpperCase();',
+      '-  return helper(upper);',
+      '+  const message = helper(upper);',
+      '+  return message;',
+      ' }',
+      '',
+    ].join('\n');
+
+    expect(parseUnifiedDiffChangedRanges(diff, workspaceRoot).get(file)).toEqual([
+      { startLine: 3, endLine: 4 },
+    ]);
+  });
+
+  it('maps deletion-only hunks to the current file line at the deletion point', () => {
+    const workspaceRoot = path.resolve('/repo');
+    const file = path.resolve(workspaceRoot, 'src/sample.ts');
+    const diff = [
+      'diff --git a/src/sample.ts b/src/sample.ts',
+      '--- a/src/sample.ts',
+      '+++ b/src/sample.ts',
+      '@@ -10,5 +10,4 @@ class Service {',
+      '   public run() {',
+      '-    console.log("debug");',
+      '     return this.runInner();',
+      '   }',
+    ].join('\n');
+
+    expect(parseUnifiedDiffChangedRanges(diff, workspaceRoot).get(file)).toEqual([
+      { startLine: 11, endLine: 11 },
+    ]);
+  });
+});
+
+describe('markChangedFunctions', () => {
+  it('marks only nodes whose source range intersects changed lines', () => {
+    const workspaceRoot = path.resolve('/repo');
+    const file = path.resolve(workspaceRoot, 'src/sample.ts');
+    const nodes: FunctionNode[] = [
+      node('greet', file, 2, 6),
+      node('Service.run', file, 10, 14),
+      node('helper', file, 20, 22),
+    ];
+    const ranges = new Map([[file, [{ startLine: 11, endLine: 11 }]]]);
+
+    expect(markChangedFunctions(nodes, ranges).map((n) => [n.name, n.changedSinceBase])).toEqual([
+      ['greet', false],
+      ['Service.run', true],
+      ['helper', false],
+    ]);
+  });
+});
+
+function node(name: string, file: string, startLine: number, endLine: number): FunctionNode {
+  return {
+    id: `${file}#${name}@${startLine}:1`,
+    name,
+    kind: 'function',
+    file,
+    range: {
+      startLine,
+      startColumn: 1,
+      endLine,
+      endColumn: 1,
+    },
+  };
+}

--- a/extension/src/git/changedRanges.ts
+++ b/extension/src/git/changedRanges.ts
@@ -1,0 +1,114 @@
+import * as path from 'path';
+import type { FunctionNode, SourceRange } from '../analyzer/types';
+
+export interface ChangedLineRange {
+  startLine: number;
+  endLine: number;
+}
+
+export type ChangedLineRangeMap = Map<string, ChangedLineRange[]>;
+
+export function parseUnifiedDiffChangedRanges(
+  diff: string,
+  workspaceRoot: string,
+): ChangedLineRangeMap {
+  const ranges: ChangedLineRangeMap = new Map();
+  let currentFile: string | undefined;
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const line of diff.split(/\r?\n/)) {
+    if (line.startsWith('+++ ')) {
+      currentFile = normalizeDiffPath(line.slice(4), workspaceRoot);
+      inHunk = false;
+      continue;
+    }
+
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+
+    if (!inHunk || !currentFile) continue;
+
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      addChangedLine(ranges, currentFile, newLine);
+      newLine += 1;
+      continue;
+    }
+
+    if (line.startsWith('-') && !line.startsWith('---')) {
+      addChangedLine(ranges, currentFile, Math.max(1, newLine));
+      continue;
+    }
+
+    if (line.startsWith(' ') || line === '') {
+      newLine += 1;
+    }
+  }
+
+  return ranges;
+}
+
+export function markChangedFunctions(
+  nodes: readonly FunctionNode[],
+  changedRanges: ChangedLineRangeMap,
+): FunctionNode[] {
+  return nodes.map((node) => ({
+    ...node,
+    changedSinceBase: isFunctionChanged(node, changedRanges),
+  }));
+}
+
+export function isFunctionChanged(
+  node: FunctionNode,
+  changedRanges: ChangedLineRangeMap,
+): boolean {
+  const ranges = changedRanges.get(normalizeFilePath(node.file));
+  if (!ranges || ranges.length === 0) return false;
+  return ranges.some((range) => rangesIntersect(node.range, range));
+}
+
+function addChangedLine(
+  ranges: ChangedLineRangeMap,
+  filePath: string,
+  line: number,
+): void {
+  const existing = ranges.get(filePath) ?? [];
+  const previous = existing[existing.length - 1];
+  if (previous && previous.endLine + 1 >= line) {
+    previous.endLine = Math.max(previous.endLine, line);
+  } else {
+    existing.push({ startLine: line, endLine: line });
+  }
+  ranges.set(filePath, existing);
+}
+
+function normalizeDiffPath(rawPath: string, workspaceRoot: string): string | undefined {
+  const diffPath = unquoteDiffPath(rawPath.trim());
+  if (!diffPath || diffPath === '/dev/null') return undefined;
+
+  const withoutPrefix = diffPath.replace(/^[ab]\//, '');
+  return normalizeFilePath(
+    path.isAbsolute(withoutPrefix)
+      ? withoutPrefix
+      : path.resolve(workspaceRoot, withoutPrefix),
+  );
+}
+
+function unquoteDiffPath(value: string): string {
+  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+    return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  }
+  return value;
+}
+
+function normalizeFilePath(filePath: string): string {
+  return path.normalize(path.resolve(filePath));
+}
+
+function rangesIntersect(left: SourceRange, right: ChangedLineRange): boolean {
+  return left.startLine <= right.endLine && right.startLine <= left.endLine;
+}

--- a/extension/src/git/vscodeGit.ts
+++ b/extension/src/git/vscodeGit.ts
@@ -1,0 +1,100 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import {
+  type ChangedLineRangeMap,
+  parseUnifiedDiffChangedRanges,
+} from './changedRanges';
+
+export interface GitChangeScanResult {
+  ranges: ChangedLineRangeMap;
+  baseRef: string;
+  unavailableReason?: string;
+}
+
+interface GitExtension {
+  getAPI(version: 1): GitApi;
+}
+
+interface GitApi {
+  repositories: GitRepository[];
+}
+
+interface GitRepository {
+  rootUri: vscode.Uri;
+  diffWith?(ref: string, path?: string): Promise<string>;
+}
+
+export const DEFAULT_GIT_BASE_BRANCH = 'main';
+
+export function getConfiguredGitBaseBranch(): string {
+  const configured = vscode.workspace
+    .getConfiguration('codetrace.git')
+    .get<string>('baseBranch', DEFAULT_GIT_BASE_BRANCH)
+    .trim();
+  return configured || DEFAULT_GIT_BASE_BRANCH;
+}
+
+export async function collectChangedLineRanges(
+  workspaceRoot: string,
+  baseRef: string = DEFAULT_GIT_BASE_BRANCH,
+): Promise<GitChangeScanResult> {
+  const empty: ChangedLineRangeMap = new Map();
+
+  try {
+    const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git');
+    if (!gitExtension) {
+      return { ranges: empty, baseRef, unavailableReason: 'VS Code Git extension is unavailable.' };
+    }
+
+    const gitApiProvider = gitExtension.isActive ? gitExtension.exports : await gitExtension.activate();
+    const git = gitApiProvider.getAPI(1);
+    const repository = findRepository(git.repositories, workspaceRoot);
+    if (!repository) {
+      return { ranges: empty, baseRef, unavailableReason: 'No Git repository found for the workspace.' };
+    }
+
+    if (typeof repository.diffWith !== 'function') {
+      return { ranges: empty, baseRef, unavailableReason: 'VS Code Git API does not expose diffWith().' };
+    }
+
+    const diff = await diffWithBase(repository, baseRef);
+    return {
+      ranges: parseUnifiedDiffChangedRanges(diff, repository.rootUri.fsPath),
+      baseRef,
+    };
+  } catch (error) {
+    return {
+      ranges: empty,
+      baseRef,
+      unavailableReason: `Git diff unavailable: ${error}`,
+    };
+  }
+}
+
+function findRepository(
+  repositories: readonly GitRepository[],
+  workspaceRoot: string,
+): GitRepository | undefined {
+  const normalizedWorkspaceRoot = normalizePath(workspaceRoot);
+  return repositories.find((repository) => {
+    const repositoryRoot = normalizePath(repository.rootUri.fsPath);
+    return (
+      normalizedWorkspaceRoot === repositoryRoot ||
+      normalizedWorkspaceRoot.startsWith(`${repositoryRoot}${path.sep}`) ||
+      repositoryRoot.startsWith(`${normalizedWorkspaceRoot}${path.sep}`)
+    );
+  });
+}
+
+async function diffWithBase(repository: GitRepository, baseRef: string): Promise<string> {
+  try {
+    return await repository.diffWith!(baseRef);
+  } catch (error) {
+    if (baseRef.startsWith('origin/')) throw error;
+    return repository.diffWith!(`origin/${baseRef}`);
+  }
+}
+
+function normalizePath(filePath: string): string {
+  return path.normalize(path.resolve(filePath));
+}

--- a/extension/src/test/suite/changedRanges.test.ts
+++ b/extension/src/test/suite/changedRanges.test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'assert';
+import * as path from 'path';
+import {
+  markChangedFunctions,
+  parseUnifiedDiffChangedRanges,
+} from '../../git/changedRanges';
+import type { FunctionNode } from '../../analyzer/types';
+
+suite('git changed range detection', () => {
+  test('collects changed line ranges from unified diff hunks', () => {
+    const workspaceRoot = path.resolve('/repo');
+    const file = path.resolve(workspaceRoot, 'src/sample.ts');
+    const diff = [
+      'diff --git a/src/sample.ts b/src/sample.ts',
+      'index 1111111..2222222 100644',
+      '--- a/src/sample.ts',
+      '+++ b/src/sample.ts',
+      '@@ -2,8 +2,9 @@ export function greet(name: string) {',
+      '   const upper = name.toUpperCase();',
+      '-  return helper(upper);',
+      '+  const message = helper(upper);',
+      '+  return message;',
+      ' }',
+      '',
+    ].join('\n');
+
+    assert.deepStrictEqual(parseUnifiedDiffChangedRanges(diff, workspaceRoot).get(file), [
+      { startLine: 3, endLine: 4 },
+    ]);
+  });
+
+  test('marks only nodes whose source range intersects changed lines', () => {
+    const workspaceRoot = path.resolve('/repo');
+    const file = path.resolve(workspaceRoot, 'src/sample.ts');
+    const nodes: FunctionNode[] = [
+      node('greet', file, 2, 6),
+      node('Service.run', file, 10, 14),
+      node('helper', file, 20, 22),
+    ];
+    const ranges = new Map([[file, [{ startLine: 11, endLine: 11 }]]]);
+
+    assert.deepStrictEqual(
+      markChangedFunctions(nodes, ranges).map((n) => [n.name, n.changedSinceBase]),
+      [
+        ['greet', false],
+        ['Service.run', true],
+        ['helper', false],
+      ],
+    );
+  });
+});
+
+function node(name: string, file: string, startLine: number, endLine: number): FunctionNode {
+  return {
+    id: `${file}#${name}@${startLine}:1`,
+    name,
+    kind: 'function',
+    file,
+    range: {
+      startLine,
+      startColumn: 1,
+      endLine,
+      endColumn: 1,
+    },
+  };
+}

--- a/frontend/src/graph/converter.test.ts
+++ b/frontend/src/graph/converter.test.ts
@@ -218,6 +218,29 @@ describe('convertGraphToElements', () => {
     expect(node?.groupIds).toEqual(['node-note-a']);
     expect(label?.groupIds).toEqual(['node-note-a']);
   });
+
+  it('visually highlights changed function nodes and stamps the flag on labels', () => {
+    const { elements } = convertGraphToElements(
+      [{ ...sampleNodes[0], changedSinceBase: true }, sampleNodes[1]],
+      sampleEdges,
+    );
+    const changedNode = elements.find((e) => e.id === 'auto-node-a');
+    const unchangedNode = elements.find((e) => e.id === 'auto-node-b');
+    const changedLabel = elements.find((e) => e.containerId === 'auto-node-a');
+
+    expect(changedNode).toMatchObject({
+      strokeColor: '#ea580c',
+      backgroundColor: '#fff7ed',
+      strokeWidth: 3,
+    });
+    expect(changedNode?.customData).toMatchObject({ changedSinceBase: true });
+    expect(changedLabel?.customData).toMatchObject({ changedSinceBase: true });
+    expect(unchangedNode).toMatchObject({
+      strokeColor: '#4f46e5',
+      backgroundColor: '#eef2ff',
+      strokeWidth: 1,
+    });
+  });
 });
 
 describe('extractPositions', () => {

--- a/frontend/src/graph/converter.ts
+++ b/frontend/src/graph/converter.ts
@@ -16,6 +16,8 @@ import {
 const AUTO_NODE_BG = '#eef2ff';
 const AUTO_NODE_STROKE = '#4f46e5';
 const AUTO_EDGE_STROKE = '#4f46e5';
+const CHANGED_NODE_BG = '#fff7ed';
+const CHANGED_NODE_STROKE = '#ea580c';
 
 export interface ConvertOptions {
   locked?: boolean;
@@ -65,7 +67,9 @@ export function convertGraphToElements(
       kind: GRAPH_ELEMENT_KIND_NODE,
       nodeId: node.id,
       source: 'auto',
+      changedSinceBase: node.changedSinceBase === true,
     };
+    const strokeColor = node.changedSinceBase ? CHANGED_NODE_STROKE : AUTO_NODE_STROKE;
     skeletons.push({
       type: 'rectangle',
       id: nodeElementId(node.id),
@@ -74,16 +78,17 @@ export function convertGraphToElements(
       width: NODE_WIDTH,
       height: NODE_HEIGHT,
       groupIds: [...(options.nodeGroupIds?.get(node.id) ?? [])],
-      strokeColor: AUTO_NODE_STROKE,
-      backgroundColor: AUTO_NODE_BG,
+      strokeColor,
+      backgroundColor: node.changedSinceBase ? CHANGED_NODE_BG : AUTO_NODE_BG,
       fillStyle: 'solid',
       roundness: { type: 3 },
+      strokeWidth: node.changedSinceBase ? 3 : 1,
       locked,
       customData,
       label: {
         text: node.name,
         fontSize: 14,
-        strokeColor: AUTO_NODE_STROKE,
+        strokeColor,
       },
     });
   }
@@ -148,11 +153,25 @@ function stampAutoCustomData(
       return {
         ...element,
         groupIds,
-        customData: { kind: GRAPH_ELEMENT_KIND_NODE, nodeId, source: 'auto' },
+        customData: {
+          kind: GRAPH_ELEMENT_KIND_NODE,
+          nodeId,
+          source: 'auto',
+          changedSinceBase: isChangedGraphNode(container?.customData),
+        },
       };
     }
   }
   return element;
+}
+
+function isChangedGraphNode(customData: unknown): boolean {
+  return (
+    typeof customData === 'object' &&
+    customData !== null &&
+    'changedSinceBase' in customData &&
+    (customData as { changedSinceBase?: unknown }).changedSinceBase === true
+  );
 }
 
 export function isAutoElement(element: ExcalidrawElementStub): boolean {

--- a/frontend/src/graph/types.ts
+++ b/frontend/src/graph/types.ts
@@ -15,6 +15,7 @@ export interface GraphNode {
   kind: GraphNodeKind;
   file: string;
   range: GraphSourceRange;
+  changedSinceBase?: boolean;
 }
 
 export interface GraphEdge {
@@ -52,6 +53,7 @@ export interface GraphCustomData {
   nodeId?: string;
   edgeKey?: string;
   source?: 'auto';
+  changedSinceBase?: boolean;
 }
 
 export function isGraphNode(value: unknown): value is GraphNode {


### PR DESCRIPTION
## Summary
- VS Code Git API로 base ref 대비 diff를 수집하고 hunk 라인과 FunctionNode range 교차를 계산합니다.
- 분석 결과에 changedSinceBase, gitBaseRef, changedNodeCount를 포함해 webview로 전달합니다.
- 변경된 자동 그래프 노드를 주황색 테두리/배경으로 강조하고 관련 단위 테스트를 추가했습니다.
- codetrace.git.baseBranch 설정을 추가해 기본 base branch를 main으로 둡니다.

## Tests
- npm.cmd exec --workspace=extension -- tsc -p ./ --noEmit
- npm.cmd exec -- jest --config extension/jest.config.cjs --runInBand extension/src/git/changedRanges.test.ts
- npm.cmd test --workspace=frontend -- --runInBand
- npm.cmd run build --workspace=extension
- npm.cmd run build --workspace=frontend

## Note
- npm.cmd test --workspace=extension 전체 VS Code 테스트는 .vscode-test Insiders 캐시의 node_modules.asar 파일 잠금(EBUSY) 때문에 로컬에서 완료하지 못했습니다.

Closes #56