### PR TITLE
feat(ci): Claude 자동 리뷰가 명시적 review state(APPROVE/CHANGES_REQUESTED) 제출

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,14 +44,30 @@ jobs:
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
-            추가 지시: blocking 이슈가 없더라도 항상 PR에 한국어 리뷰 코멘트를 남겨라.
-            코멘트에는 다음을 포함한다:
+            추가 지시: 항상 PR에 한국어로 GitHub Pull Request Review를 제출하라.
+            본문에는 다음을 포함한다:
               - 한 줄 변경 요약
               - 잘 된 점 (있다면)
               - 우려되는 점 / 후속에서 챙기면 좋은 점 (있다면)
               - 검증 결과 (테스트/빌드 통과 여부, 직접 실행한 검증 항목)
-            blocking 이슈가 있으면 별도의 review (CHANGES_REQUESTED) 로 남기고,
-            없으면 일반 issue comment 로 남겨라.
+
+            Review state 결정 규칙:
+              - APPROVE: 다음을 모두 만족할 때
+                  · 명백한 버그/회귀/보안 이슈 없음
+                  · CI status check 모두 success 또는 skipped
+                  · 코드 품질·테스트 커버리지·문서가 받아들일 만한 수준
+                  · 의문이 있어도 후속 이슈로 남길 수 있는 수준이며 머지 가능
+              - REQUEST_CHANGES: blocking 이슈가 있을 때
+                  · 머지 전에 반드시 고쳐야 할 버그/회귀
+                  · 보안/데이터 손실 위험
+                  · 테스트나 빌드를 깨는 변경
+                  · 합의되지 않은 destructive 변경
+              - COMMENT: 위 둘에 해당하지 않을 때 (예: 정보성 의견만, 또는 판단 보류)
+
+            self-approve 주의: 이 워크플로는 화이트리스트 collaborator의 PR에 자동 실행되며,
+            APPROVE를 자동으로 부여한다. 팀이 사람 리뷰를 추가로 받기 원할 경우 GitHub
+            branch protection rule에서 사람 리뷰 1명 필수를 설정해야 한다 (현재 정책에서는
+            APPROVE 후 작성자 본인이 머지하는 흐름을 허용한다).
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

Claude 자동 PR 리뷰가 free-form 코멘트만 남기던 것을 GitHub Pull Request Review API로 명시적 state(APPROVE / REQUEST_CHANGES / COMMENT)를 제출하도록 바꾼다. blocking 이슈가 없으면 자동 APPROVE까지 부여하여 작은 PR의 머지 latency를 줄인다.

## Changes

- `.github/workflows/claude-code-review.yml`: prompt에 Review state 결정 규칙 추가
  - APPROVE: 명백한 버그/회귀/보안 없음 + CI green + 후속 이슈로 남길 수 있는 수준의 의문만 남음
  - REQUEST_CHANGES: 머지 전 반드시 고쳐야 할 blocker (버그/보안/빌드 깨짐/미합의 destructive)
  - COMMENT: 위 둘 외 (정보성 의견, 판단 보류)
- self-approve 정책 명시: C안(허용) — branch protection rule로 추가 사람 리뷰 게이트 가능

## Related Issue

Closes #88

## 배경

PR #84로 항상 코멘트는 남기게 했지만 review state 미지정으로 reviewDecision이 REVIEW_REQUIRED에 묶여 있었음. 자동 리뷰가 사실상 정보 전달용에 그치고 있어, blocking 없는 작은 PR도 사람 리뷰를 기다리며 lead time이 늘어남.

## 위험

- self-approve 가능: 작성자 본인 PR이 자동 APPROVE → 본인이 머지하는 흐름 허용. 의도적 정책(C안). main 등 중요 브랜치는 GitHub branch protection rule로 사람 리뷰 1명 필수를 별도 설정해 보호.
- 자동 APPROVE의 오판 가능성: blocking criterion이 prompt-driven이라 false positive(approve 안 해야 하는데 함) 발생 가능. 첫 몇 PR은 결과를 확인하면서 prompt 보강할 것.

## Test plan

- [x] YAML multiline `|` 블록 syntax 점검
- [ ] 머지 후 develop 기반 다음 PR이 열릴 때:
  - 자동 리뷰가 GitHub Review로 제출되고 (단순 issue comment 아님)
  - state가 APPROVED / CHANGES_REQUESTED / COMMENTED 중 하나로 명시됨
  - 한국어 본문(요약/잘된 점/우려/검증) 포함
- [ ] blocking 없는 작은 PR에서 reviewDecision이 APPROVED로 자동 변경되는지 확인
