### PR TITLE
chore: sync main into develop (Claude review explicit state)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -44,14 +44,30 @@ jobs:
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
-            추가 지시: blocking 이슈가 없더라도 항상 PR에 한국어 리뷰 코멘트를 남겨라.
-            코멘트에는 다음을 포함한다:
+            추가 지시: 항상 PR에 한국어로 GitHub Pull Request Review를 제출하라.
+            본문에는 다음을 포함한다:
               - 한 줄 변경 요약
               - 잘 된 점 (있다면)
               - 우려되는 점 / 후속에서 챙기면 좋은 점 (있다면)
               - 검증 결과 (테스트/빌드 통과 여부, 직접 실행한 검증 항목)
-            blocking 이슈가 있으면 별도의 review (CHANGES_REQUESTED) 로 남기고,
-            없으면 일반 issue comment 로 남겨라.
+
+            Review state 결정 규칙:
+              - APPROVE: 다음을 모두 만족할 때
+                  · 명백한 버그/회귀/보안 이슈 없음
+                  · CI status check 모두 success 또는 skipped
+                  · 코드 품질·테스트 커버리지·문서가 받아들일 만한 수준
+                  · 의문이 있어도 후속 이슈로 남길 수 있는 수준이며 머지 가능
+              - REQUEST_CHANGES: blocking 이슈가 있을 때
+                  · 머지 전에 반드시 고쳐야 할 버그/회귀
+                  · 보안/데이터 손실 위험
+                  · 테스트나 빌드를 깨는 변경
+                  · 합의되지 않은 destructive 변경
+              - COMMENT: 위 둘에 해당하지 않을 때 (예: 정보성 의견만, 또는 판단 보류)
+
+            self-approve 주의: 이 워크플로는 화이트리스트 collaborator의 PR에 자동 실행되며,
+            APPROVE를 자동으로 부여한다. 팀이 사람 리뷰를 추가로 받기 원할 경우 GitHub
+            branch protection rule에서 사람 리뷰 1명 필수를 설정해야 한다 (현재 정책에서는
+            APPROVE 후 작성자 본인이 머지하는 흐름을 허용한다).
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary

PR #89(`feat(ci): Claude 자동 리뷰가 명시적 review state...`)가 main에 머지되어 develop 워크플로가 옛 버전이 된 상태입니다. main → develop 동기화로 develop 기반 PR에서도 자동 APPROVE/CHANGES_REQUESTED 룰이 작동하도록 합니다.

## Changes

- `.github/workflows/claude-code-review.yml` (main에서 가져옴): prompt에 Review state 결정 규칙(APPROVE / REQUEST_CHANGES / COMMENT) 추가, self-approve 정책(C안) 명시

## Related Issue

없음 (브랜치 동기화)

## 배경

워크플로는 main이 source of truth이고 PR #89로 main에 직접 적용되었음. develop에 동일한 변경이 들어와야 develop 기반 PR(#86 등)에서도 새 prompt가 적용됨.

## Test plan

- [x] 자동 sync hook이 충돌 없이 머지 가능 확인
- [ ] 머지 후 develop 기반 다음 PR push 시 Claude가 명시적 Review state로 제출하는지 확인
