### PR TITLE
feat(extension): sticky review round-trip sync

### DIFF
--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -95,8 +95,7 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
           return;
         }
         try {
-          const review = await persistReviewSticky(workspaceRoot, msg.review);
-          webviewPanel.webview.postMessage({ type: 'reviewSticky:saved', review });
+          await persistReviewSticky(workspaceRoot, msg.review);
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           vscode.window.showErrorMessage(`CodeTrace: failed to save review sticky. ${message}`);

--- a/extension/src/CanvasEditorProvider.ts
+++ b/extension/src/CanvasEditorProvider.ts
@@ -1,4 +1,11 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+
+import {
+  loadReviewStickies,
+  persistReviewSticky,
+  type PersistReviewStickyInput,
+} from './reviews/reviewRoundTrip';
 
 export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
   static readonly viewType = 'codetrace.canvasEditor';
@@ -28,6 +35,8 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     document: vscode.TextDocument,
     webviewPanel: vscode.WebviewPanel,
   ): Promise<void> {
+    const workspaceRoot = this._getWorkspaceRoot(document);
+
     webviewPanel.webview.options = {
       enableScripts: true,
       localResourceRoots: [
@@ -35,8 +44,22 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       ],
     };
 
+    let reviewStickies: unknown[] = [];
+    if (workspaceRoot) {
+      try {
+        reviewStickies = await loadReviewStickies(workspaceRoot);
+      } catch (error) {
+        console.error('CodeTrace: failed to load review stickies', error);
+        vscode.window.showWarningMessage('CodeTrace: failed to load review stickies for this canvas.');
+      }
+    }
+
     try {
-      webviewPanel.webview.html = await this._getHtml(webviewPanel.webview, document.getText());
+      webviewPanel.webview.html = await this._getHtml(
+        webviewPanel.webview,
+        document.getText(),
+        reviewStickies,
+      );
     } catch (error) {
       console.error('CodeTrace: failed to load webview assets', error);
       webviewPanel.webview.html = this._getFallbackHtml(
@@ -66,6 +89,18 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       } else if (msg.type === 'saveFile' && typeof msg.content === 'string') {
         await this._updateDocument(document, msg.content);
         await document.save();
+      } else if (isReviewStickyCommitMessage(msg)) {
+        if (!workspaceRoot) {
+          vscode.window.showWarningMessage('CodeTrace: open a workspace before saving review stickies.');
+          return;
+        }
+        try {
+          const review = await persistReviewSticky(workspaceRoot, msg.review);
+          webviewPanel.webview.postMessage({ type: 'reviewSticky:saved', review });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          vscode.window.showErrorMessage(`CodeTrace: failed to save review sticky. ${message}`);
+        }
       }
     });
 
@@ -92,7 +127,11 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
     await vscode.workspace.applyEdit(edit);
   }
 
-  private async _getHtml(webview: vscode.Webview, initialContent: string): Promise<string> {
+  private async _getHtml(
+    webview: vscode.Webview,
+    initialContent: string,
+    reviewStickies: unknown[],
+  ): Promise<string> {
     const nonce = this._nonce();
 
     const assetsRoot = vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'webview', 'assets');
@@ -129,6 +168,7 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
     window.__codetrace_initialContent = ${this._scriptString(initialContent)};
+    window.__codetrace_initialReviewStickies = ${this._scriptJson(reviewStickies)};
 
     window.addEventListener('message', event => {
       const data = event.data ?? {};
@@ -146,6 +186,10 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
 
     window.__codetrace_saveFile = (content) => {
       vscode.postMessage({ type: 'saveFile', content });
+    };
+
+    window.__codetrace_saveReviewSticky = (review) => {
+      vscode.postMessage({ type: 'reviewSticky:commit', review });
     };
   </script>
 `,
@@ -221,8 +265,37 @@ export class CanvasEditorProvider implements vscode.CustomTextEditorProvider {
       .replace(/\u2029/g, '\\u2029');
   }
 
+  private _scriptJson(value: unknown): string {
+    return JSON.stringify(value)
+      .replace(/</g, '\\u003c')
+      .replace(/\u2028/g, '\\u2028')
+      .replace(/\u2029/g, '\\u2029');
+  }
+
+  private _getWorkspaceRoot(document: vscode.TextDocument): string | undefined {
+    const folder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (folder) return folder.uri.fsPath;
+    if (document.uri.scheme === 'file') return path.dirname(document.uri.fsPath);
+    return undefined;
+  }
+
   private _nonce(): string {
     const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
     return Array.from({ length: 32 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
   }
+}
+
+function isReviewStickyCommitMessage(
+  value: unknown,
+): value is { type: 'reviewSticky:commit'; review: PersistReviewStickyInput } {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  if (record.type !== 'reviewSticky:commit') return false;
+  if (!record.review || typeof record.review !== 'object') return false;
+  const review = record.review as Record<string, unknown>;
+  return (
+    typeof review.reviewId === 'string' &&
+    typeof review.title === 'string' &&
+    typeof review.body === 'string'
+  );
 }

--- a/extension/src/reviews/reviewRoundTrip.test.ts
+++ b/extension/src/reviews/reviewRoundTrip.test.ts
@@ -1,0 +1,174 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+import { loadReviewStickies, persistReviewSticky } from './reviewRoundTrip';
+
+describe('review round-trip storage', () => {
+  let workspaceRoot: string;
+
+  beforeEach(async () => {
+    workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'codetrace-review-'));
+    await fs.mkdir(path.join(workspaceRoot, 'src'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  it('writes a source marker and markdown body, then loads them as one active sticky', async () => {
+    await fs.writeFile(
+      path.join(workspaceRoot, 'src', 'demo.ts'),
+      'export function demo() {\n  return 1;\n}\n',
+      'utf8',
+    );
+
+    await persistReviewSticky(workspaceRoot, {
+      reviewId: 'r1',
+      title: 'Check return value',
+      body: 'line one\nline two',
+      anchor: {
+        nodeId: 'src/demo.ts#demo',
+        symbolId: 'src/demo.ts#demo',
+        file: 'src/demo.ts',
+        range: { startLine: 1, startColumn: 1, endLine: 3, endColumn: 1 },
+      },
+    });
+
+    const source = await fs.readFile(path.join(workspaceRoot, 'src', 'demo.ts'), 'utf8');
+    expect(source).toContain('// review: r1 Check return value');
+    expect(source).toContain('// review-body: r1 line one');
+    expect(source).toContain('// review-body: r1 line two');
+
+    const markdown = await fs.readFile(path.join(workspaceRoot, '.codetrace', 'reviews', 'r1.md'), 'utf8');
+    expect(markdown).toContain('anchorNodeId: "src/demo.ts#demo"');
+    expect(markdown).toContain('file: "src/demo.ts"');
+    expect(markdown).toContain('line one\nline two');
+
+    const loaded = await loadReviewStickies(workspaceRoot);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toMatchObject({
+      reviewId: 'r1',
+      title: 'Check return value',
+      body: 'line one\nline two',
+      status: 'active',
+      source: 'both',
+    });
+  });
+
+  it('keeps long bodies in markdown without expanding source comments', async () => {
+    await fs.writeFile(path.join(workspaceRoot, 'src', 'demo.py'), 'def demo():\n    return 1\n', 'utf8');
+
+    await persistReviewSticky(workspaceRoot, {
+      reviewId: 'long-body',
+      title: 'Long note',
+      body: ['1', '2', '3', '4', '5', '6'].join('\n'),
+      anchor: {
+        nodeId: 'src/demo.py#demo',
+        symbolId: 'src/demo.py#demo',
+        file: 'src/demo.py',
+        range: { startLine: 1, startColumn: 1, endLine: 2, endColumn: 12 },
+      },
+    });
+
+    const source = await fs.readFile(path.join(workspaceRoot, 'src', 'demo.py'), 'utf8');
+    expect(source).toContain('# review: long-body Long note');
+    expect(source).not.toContain('review-body: long-body');
+
+    const loaded = await loadReviewStickies(workspaceRoot);
+    expect(loaded[0].body).toBe('1\n2\n3\n4\n5\n6');
+    expect(loaded[0].status).toBe('active');
+  });
+
+  it('replaces an existing marker block for the same review id', async () => {
+    await fs.writeFile(path.join(workspaceRoot, 'src', 'demo.ts'), 'export function demo() {}\n', 'utf8');
+
+    const anchor = {
+      nodeId: 'src/demo.ts#demo',
+      symbolId: 'src/demo.ts#demo',
+      file: 'src/demo.ts',
+      range: { startLine: 1, startColumn: 1, endLine: 1, endColumn: 26 },
+    };
+
+    await persistReviewSticky(workspaceRoot, {
+      reviewId: 'replace-me',
+      title: 'Old',
+      body: 'old body',
+      anchor,
+    });
+    await persistReviewSticky(workspaceRoot, {
+      reviewId: 'replace-me',
+      title: 'New',
+      body: 'new body',
+      anchor,
+    });
+
+    const source = await fs.readFile(path.join(workspaceRoot, 'src', 'demo.ts'), 'utf8');
+    expect(source.match(/review: replace-me/g)).toHaveLength(1);
+    expect(source).toContain('// review: replace-me New');
+    expect(source).toContain('// review-body: replace-me new body');
+    expect(source).not.toContain('Old');
+  });
+
+  it('rejects source anchors outside the workspace', async () => {
+    await expect(
+      persistReviewSticky(workspaceRoot, {
+        reviewId: 'outside',
+        title: 'Outside',
+        body: 'Body',
+        anchor: {
+          file: '../outside.ts',
+          range: { startLine: 1, startColumn: 1, endLine: 1, endColumn: 1 },
+        },
+      }),
+    ).rejects.toThrow('outside the workspace');
+  });
+
+  it('reports orphan markers, orphan bodies, and merge conflict records', async () => {
+    await fs.writeFile(
+      path.join(workspaceRoot, 'src', 'marker.ts'),
+      '// review: marker-only Missing body\nexport const value = 1;\n',
+      'utf8',
+    );
+    await fs.mkdir(path.join(workspaceRoot, '.codetrace', 'reviews'), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceRoot, '.codetrace', 'reviews', 'body-only.md'),
+      [
+        '---',
+        'id: "body-only"',
+        'title: "Missing marker"',
+        'file: "src/missing.ts"',
+        'createdAt: "2026-05-04T00:00:00.000Z"',
+        'draft: false',
+        '---',
+        'Stored body',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    await fs.writeFile(
+      path.join(workspaceRoot, '.codetrace', 'reviews', 'conflict.md'),
+      [
+        '---',
+        'id: "conflict"',
+        'title: "Conflict"',
+        'draft: false',
+        '---',
+        '<<<<<<< HEAD',
+        'body',
+        '=======',
+        'other',
+        '>>>>>>> branch',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const loaded = await loadReviewStickies(workspaceRoot);
+    const byId = new Map(loaded.map((review) => [review.reviewId, review]));
+
+    expect(byId.get('marker-only')?.status).toBe('orphan-marker');
+    expect(byId.get('body-only')?.status).toBe('orphan-body');
+    expect(byId.get('conflict')?.status).toBe('merge-conflict');
+  });
+});

--- a/extension/src/reviews/reviewRoundTrip.test.ts
+++ b/extension/src/reviews/reviewRoundTrip.test.ts
@@ -23,7 +23,7 @@ describe('review round-trip storage', () => {
       'utf8',
     );
 
-    await persistReviewSticky(workspaceRoot, {
+    const saved = await persistReviewSticky(workspaceRoot, {
       reviewId: 'r1',
       title: 'Check return value',
       body: 'line one\nline two',
@@ -54,6 +54,8 @@ describe('review round-trip storage', () => {
       status: 'active',
       source: 'both',
     });
+    expect(loaded[0].anchor?.lineHash).toBe(saved.anchor?.lineHash);
+    expect(loaded[0].anchor?.range?.startLine).toBe(4);
   });
 
   it('keeps long bodies in markdown without expanding source comments', async () => {
@@ -108,6 +110,63 @@ describe('review round-trip storage', () => {
     expect(source).toContain('// review: replace-me New');
     expect(source).toContain('// review-body: replace-me new body');
     expect(source).not.toContain('Old');
+  });
+
+  it('keeps lineHash stable when an existing marker block changes length', async () => {
+    await fs.writeFile(
+      path.join(workspaceRoot, 'src', 'hash.ts'),
+      'export function hashMe() {\n  return 1;\n}\n',
+      'utf8',
+    );
+
+    const first = await persistReviewSticky(workspaceRoot, {
+      reviewId: 'hash-note',
+      title: 'Hash',
+      body: 'one',
+      anchor: {
+        nodeId: 'src/hash.ts#hashMe',
+        symbolId: 'src/hash.ts#hashMe',
+        file: 'src/hash.ts',
+        range: { startLine: 1, startColumn: 1, endLine: 3, endColumn: 1 },
+      },
+    });
+    const second = await persistReviewSticky(workspaceRoot, {
+      reviewId: 'hash-note',
+      title: 'Hash',
+      body: 'one\ntwo\nthree',
+      anchor: first.anchor,
+    });
+
+    const loaded = await loadReviewStickies(workspaceRoot);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].anchor?.lineHash).toBe(second.anchor?.lineHash);
+    expect(loaded[0].anchor?.range?.startLine).toBe(second.anchor?.range?.startLine);
+  });
+
+  it('marks only marker blocks that overlap a merge conflict region', async () => {
+    await fs.writeFile(
+      path.join(workspaceRoot, 'src', 'conflict.ts'),
+      [
+        '// review: clean Clean marker',
+        '// review-body: clean ok',
+        'export function clean() {}',
+        '<<<<<<< HEAD',
+        '// review: conflicted Conflict marker',
+        '// review-body: conflicted left',
+        '=======',
+        '// review-body: conflicted right',
+        '>>>>>>> branch',
+        'export function conflicted() {}',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const loaded = await loadReviewStickies(workspaceRoot);
+    const byId = new Map(loaded.map((review) => [review.reviewId, review]));
+
+    expect(byId.get('clean')?.status).toBe('orphan-marker');
+    expect(byId.get('conflicted')?.status).toBe('merge-conflict');
   });
 
   it('rejects source anchors outside the workspace', async () => {

--- a/extension/src/reviews/reviewRoundTrip.ts
+++ b/extension/src/reviews/reviewRoundTrip.ts
@@ -1,0 +1,572 @@
+import { createHash } from 'crypto';
+import type { Dirent } from 'fs';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+export interface ReviewSourceRange {
+  startLine: number;
+  startColumn: number;
+  endLine: number;
+  endColumn: number;
+}
+
+export interface ReviewAnchor {
+  nodeId?: string;
+  symbolId?: string;
+  file?: string;
+  range?: ReviewSourceRange;
+  lineHash?: string;
+}
+
+export type ReviewStickyStatus =
+  | 'active'
+  | 'orphan-marker'
+  | 'orphan-body'
+  | 'merge-conflict'
+  | 'anchor-lost';
+
+export interface PersistReviewStickyInput {
+  reviewId: string;
+  title: string;
+  body: string;
+  draft?: boolean;
+  createdAt?: string;
+  anchor?: ReviewAnchor;
+}
+
+export interface LoadedReviewSticky {
+  reviewId: string;
+  title: string;
+  body: string;
+  draft?: boolean;
+  createdAt?: string;
+  anchor?: ReviewAnchor;
+  status: ReviewStickyStatus;
+  source: 'marker' | 'body' | 'both';
+  warning?: string;
+}
+
+interface MarkerRecord {
+  reviewId: string;
+  title: string;
+  body: string;
+  file: string;
+  line: number;
+  lineHash?: string;
+  hasConflict: boolean;
+}
+
+interface BodyRecord {
+  reviewId: string;
+  title: string;
+  body: string;
+  draft?: boolean;
+  createdAt?: string;
+  anchor?: ReviewAnchor;
+  hasConflict: boolean;
+}
+
+const REVIEW_BODY_DIR = path.join('.codetrace', 'reviews');
+const SUPPORTED_COMMENT_PREFIXES = new Map<string, string>([
+  ['.ts', '//'],
+  ['.tsx', '//'],
+  ['.js', '//'],
+  ['.jsx', '//'],
+  ['.java', '//'],
+  ['.go', '//'],
+  ['.py', '#'],
+]);
+
+const SKIPPED_DIRECTORIES = new Set([
+  '.git',
+  '.codetrace',
+  'node_modules',
+  'dist',
+  'out',
+  'coverage',
+]);
+
+const MARKER_PATTERN = /^(\s*)(\/\/|#)\s*review:\s+(\S+)(?:\s+(.*))?$/;
+const MARKER_BODY_PATTERN = /^(\s*)(\/\/|#)\s*review-body:\s+(\S+)(?:\s?(.*))?$/;
+const CONFLICT_PATTERN = /^(?:<<<<<<<|=======|>>>>>>>)(?:\s|$)/m;
+
+export function isSupportedReviewSource(filePath: string): boolean {
+  return SUPPORTED_COMMENT_PREFIXES.has(path.extname(filePath));
+}
+
+export async function persistReviewSticky(
+  workspaceRoot: string,
+  input: PersistReviewStickyInput,
+): Promise<LoadedReviewSticky> {
+  const review = normalizePersistInput(input);
+  const createdAt = review.createdAt ?? new Date().toISOString();
+  const anchor = await hydrateAnchor(workspaceRoot, review.anchor);
+  const withAnchor: PersistReviewStickyInput = { ...review, createdAt, anchor };
+
+  await writeReviewBody(workspaceRoot, withAnchor);
+
+  if (anchor?.file && anchor.range && isSupportedReviewSource(anchor.file)) {
+    await upsertSourceMarker(workspaceRoot, withAnchor, anchor);
+  }
+
+  return {
+    reviewId: withAnchor.reviewId,
+    title: withAnchor.title,
+    body: withAnchor.body,
+    draft: withAnchor.draft,
+    createdAt,
+    anchor,
+    status: 'active',
+    source: anchor?.file ? 'both' : 'body',
+  };
+}
+
+export async function loadReviewStickies(workspaceRoot: string): Promise<LoadedReviewSticky[]> {
+  const [bodies, markers] = await Promise.all([
+    readReviewBodies(workspaceRoot),
+    scanReviewMarkers(workspaceRoot),
+  ]);
+
+  const ids = new Set<string>([...bodies.keys(), ...markers.keys()]);
+  const reviews: LoadedReviewSticky[] = [];
+
+  for (const reviewId of Array.from(ids).sort()) {
+    const body = bodies.get(reviewId);
+    const marker = markers.get(reviewId);
+
+    if (body && marker) {
+      const anchor = {
+        ...body.anchor,
+        file: body.anchor?.file ?? marker.file,
+        lineHash: body.anchor?.lineHash ?? marker.lineHash,
+      };
+      const hasConflict = body.hasConflict || marker.hasConflict;
+      reviews.push({
+        reviewId,
+        title: body.title || marker.title,
+        body: body.body || marker.body,
+        draft: body.draft,
+        createdAt: body.createdAt,
+        anchor,
+        status: hasConflict ? 'merge-conflict' : 'active',
+        source: 'both',
+        warning: hasConflict ? 'Review contains merge conflict markers.' : undefined,
+      });
+      continue;
+    }
+
+    if (marker) {
+      reviews.push({
+        reviewId,
+        title: marker.title,
+        body: marker.body,
+        anchor: {
+          file: marker.file,
+          range: {
+            startLine: marker.line + 1,
+            startColumn: 0,
+            endLine: marker.line + 1,
+            endColumn: 0,
+          },
+          lineHash: marker.lineHash,
+        },
+        status: marker.hasConflict ? 'merge-conflict' : 'orphan-marker',
+        source: 'marker',
+        warning: marker.hasConflict
+          ? 'Source marker contains merge conflict markers.'
+          : 'Source marker has no matching .codetrace review body.',
+      });
+      continue;
+    }
+
+    if (body) {
+      reviews.push({
+        reviewId,
+        title: body.title,
+        body: body.body,
+        draft: body.draft,
+        createdAt: body.createdAt,
+        anchor: body.anchor,
+        status: body.hasConflict ? 'merge-conflict' : 'orphan-body',
+        source: 'body',
+        warning: body.hasConflict
+          ? 'Review body contains merge conflict markers.'
+          : 'Review body has no matching source marker.',
+      });
+    }
+  }
+
+  return reviews;
+}
+
+async function hydrateAnchor(
+  workspaceRoot: string,
+  anchor: ReviewAnchor | undefined,
+): Promise<ReviewAnchor | undefined> {
+  if (!anchor?.file) return anchor;
+  const filePath = resolveWorkspacePath(workspaceRoot, anchor.file);
+  let lineHash = anchor.lineHash;
+
+  if (!lineHash && anchor.range) {
+    try {
+      const content = await fs.readFile(filePath, 'utf8');
+      lineHash = hashLine(splitLines(content)[sourceLineIndex(anchor.range.startLine)] ?? '');
+    } catch {
+      lineHash = undefined;
+    }
+  }
+
+  return {
+    ...anchor,
+    file: toWorkspaceRelativePath(workspaceRoot, filePath),
+    lineHash,
+  };
+}
+
+async function upsertSourceMarker(
+  workspaceRoot: string,
+  review: PersistReviewStickyInput,
+  anchor: ReviewAnchor,
+): Promise<void> {
+  if (!anchor.file || !anchor.range) return;
+
+  const filePath = resolveWorkspacePath(workspaceRoot, anchor.file);
+  const prefix = SUPPORTED_COMMENT_PREFIXES.get(path.extname(filePath));
+  if (!prefix) return;
+
+  const content = await fs.readFile(filePath, 'utf8');
+  const eol = content.includes('\r\n') ? '\r\n' : '\n';
+  const trailingNewline = content.endsWith('\n');
+  const lines = splitLines(content);
+  const insertAt = clampLine(sourceLineIndex(anchor.range.startLine), lines.length);
+  const indentation = readLineIndentation(lines[insertAt] ?? '');
+  const markerBlock = buildMarkerBlock(prefix, indentation, review);
+  const markerRange = findMarkerRange(lines, review.reviewId);
+
+  if (markerRange) {
+    lines.splice(markerRange.start, markerRange.end - markerRange.start, ...markerBlock);
+  } else {
+    lines.splice(insertAt, 0, ...markerBlock);
+  }
+
+  await fs.writeFile(filePath, `${lines.join(eol)}${trailingNewline ? eol : ''}`, 'utf8');
+}
+
+function buildMarkerBlock(
+  prefix: string,
+  indentation: string,
+  review: PersistReviewStickyInput,
+): string[] {
+  const title = singleLine(review.title) || 'Review note';
+  const lines = [`${indentation}${prefix} review: ${review.reviewId} ${title}`];
+  const bodyLines = review.body.split(/\r?\n/);
+
+  if (bodyLines.length <= 5) {
+    for (const line of bodyLines) {
+      if (line.length === 0) {
+        lines.push(`${indentation}${prefix} review-body: ${review.reviewId}`);
+      } else {
+        lines.push(`${indentation}${prefix} review-body: ${review.reviewId} ${line}`);
+      }
+    }
+  }
+
+  return lines;
+}
+
+async function writeReviewBody(
+  workspaceRoot: string,
+  review: PersistReviewStickyInput,
+): Promise<void> {
+  const bodyDir = path.join(workspaceRoot, REVIEW_BODY_DIR);
+  await fs.mkdir(bodyDir, { recursive: true });
+  const bodyPath = path.join(bodyDir, `${safeFileName(review.reviewId)}.md`);
+  await fs.writeFile(bodyPath, serializeReviewBody(review), 'utf8');
+}
+
+function serializeReviewBody(review: PersistReviewStickyInput): string {
+  const anchor = review.anchor ?? {};
+  const frontMatter: Record<string, unknown> = {
+    id: review.reviewId,
+    title: review.title,
+    anchorNodeId: anchor.nodeId,
+    symbolId: anchor.symbolId,
+    file: anchor.file,
+    startLine: anchor.range?.startLine,
+    startColumn: anchor.range?.startColumn,
+    endLine: anchor.range?.endLine,
+    endColumn: anchor.range?.endColumn,
+    lineHash: anchor.lineHash,
+    createdAt: review.createdAt,
+    draft: review.draft ?? false,
+  };
+
+  const yaml = Object.entries(frontMatter)
+    .filter(([, value]) => value !== undefined)
+    .map(([key, value]) => `${key}: ${encodeFrontMatterValue(value)}`)
+    .join('\n');
+
+  return `---\n${yaml}\n---\n${review.body.replace(/\r\n/g, '\n')}\n`;
+}
+
+async function readReviewBodies(workspaceRoot: string): Promise<Map<string, BodyRecord>> {
+  const bodyDir = path.join(workspaceRoot, REVIEW_BODY_DIR);
+  const records = new Map<string, BodyRecord>();
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(bodyDir);
+  } catch {
+    return records;
+  }
+
+  for (const entry of entries) {
+    if (path.extname(entry).toLowerCase() !== '.md') continue;
+    const filePath = path.join(bodyDir, entry);
+    const content = await fs.readFile(filePath, 'utf8');
+    const parsed = parseReviewBody(content);
+    const reviewId = parsed.reviewId || path.basename(entry, '.md');
+    if (!reviewId) continue;
+    records.set(reviewId, {
+      ...parsed,
+      reviewId,
+      hasConflict: CONFLICT_PATTERN.test(content),
+    });
+  }
+
+  return records;
+}
+
+async function scanReviewMarkers(workspaceRoot: string): Promise<Map<string, MarkerRecord>> {
+  const records = new Map<string, MarkerRecord>();
+  const files = await listSourceFiles(workspaceRoot);
+
+  for (const filePath of files) {
+    const content = await fs.readFile(filePath, 'utf8');
+    const hasConflict = CONFLICT_PATTERN.test(content);
+    const relativeFile = toWorkspaceRelativePath(workspaceRoot, filePath);
+    const lines = splitLines(content);
+
+    for (let index = 0; index < lines.length; index += 1) {
+      const match = lines[index].match(MARKER_PATTERN);
+      if (!match) continue;
+      const reviewId = match[3];
+      const title = match[4]?.trim() ?? '';
+      const bodyLines: string[] = [];
+      let cursor = index + 1;
+
+      while (cursor < lines.length) {
+        const bodyMatch = lines[cursor].match(MARKER_BODY_PATTERN);
+        if (!bodyMatch || bodyMatch[3] !== reviewId) break;
+        bodyLines.push(bodyMatch[4] ?? '');
+        cursor += 1;
+      }
+
+      records.set(reviewId, {
+        reviewId,
+        title,
+        body: bodyLines.join('\n'),
+        file: relativeFile,
+        line: index,
+        lineHash: hashLine(lines[cursor] ?? lines[index]),
+        hasConflict,
+      });
+      index = cursor - 1;
+    }
+  }
+
+  return records;
+}
+
+async function listSourceFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+
+  async function visit(directory: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const filePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+          await visit(filePath);
+        }
+        continue;
+      }
+
+      if (entry.isFile() && isSupportedReviewSource(filePath)) {
+        files.push(filePath);
+      }
+    }
+  }
+
+  await visit(root);
+  return files;
+}
+
+function parseReviewBody(content: string): BodyRecord {
+  const normalized = content.replace(/\r\n/g, '\n');
+  const match = normalized.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  const frontMatter = match ? parseFrontMatter(match[1]) : {};
+  const body = match ? trimFinalNewline(match[2]) : trimFinalNewline(normalized);
+  const reviewId = stringValue(frontMatter.id);
+  const anchor = readAnchor(frontMatter);
+
+  return {
+    reviewId: reviewId ?? '',
+    title: stringValue(frontMatter.title) ?? '',
+    body,
+    draft: booleanValue(frontMatter.draft),
+    createdAt: stringValue(frontMatter.createdAt),
+    anchor,
+    hasConflict: CONFLICT_PATTERN.test(content),
+  };
+}
+
+function parseFrontMatter(value: string): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const line of value.split('\n')) {
+    const index = line.indexOf(':');
+    if (index <= 0) continue;
+    const key = line.slice(0, index).trim();
+    const raw = line.slice(index + 1).trim();
+    out[key] = decodeFrontMatterValue(raw);
+  }
+  return out;
+}
+
+function readAnchor(frontMatter: Record<string, unknown>): ReviewAnchor | undefined {
+  const nodeId = stringValue(frontMatter.anchorNodeId);
+  const symbolId = stringValue(frontMatter.symbolId);
+  const file = stringValue(frontMatter.file);
+  const startLine = numberValue(frontMatter.startLine);
+  const startColumn = numberValue(frontMatter.startColumn);
+  const endLine = numberValue(frontMatter.endLine);
+  const endColumn = numberValue(frontMatter.endColumn);
+  const lineHash = stringValue(frontMatter.lineHash);
+  const range =
+    startLine === undefined ||
+    startColumn === undefined ||
+    endLine === undefined ||
+    endColumn === undefined
+      ? undefined
+      : { startLine, startColumn, endLine, endColumn };
+
+  if (!nodeId && !symbolId && !file && !range && !lineHash) return undefined;
+  return { nodeId, symbolId, file, range, lineHash };
+}
+
+function normalizePersistInput(input: PersistReviewStickyInput): PersistReviewStickyInput {
+  const reviewId = singleLine(input.reviewId);
+  if (!reviewId) {
+    throw new Error('CodeTrace review sticky requires a reviewId.');
+  }
+
+  return {
+    ...input,
+    reviewId,
+    title: singleLine(input.title),
+    body: input.body.replace(/\r\n/g, '\n'),
+  };
+}
+
+function resolveWorkspacePath(workspaceRoot: string, file: string): string {
+  const root = path.resolve(workspaceRoot);
+  const target = path.resolve(root, file);
+  const relative = path.relative(root, target);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Review file is outside the workspace: ${file}`);
+  }
+  return target;
+}
+
+function toWorkspaceRelativePath(workspaceRoot: string, filePath: string): string {
+  return path.relative(workspaceRoot, filePath).split(path.sep).join('/');
+}
+
+function findMarkerRange(
+  lines: readonly string[],
+  reviewId: string,
+): { start: number; end: number } | undefined {
+  for (let index = 0; index < lines.length; index += 1) {
+    const match = lines[index].match(MARKER_PATTERN);
+    if (!match || match[3] !== reviewId) continue;
+    let end = index + 1;
+    while (end < lines.length) {
+      const bodyMatch = lines[end].match(MARKER_BODY_PATTERN);
+      if (!bodyMatch || bodyMatch[3] !== reviewId) break;
+      end += 1;
+    }
+    return { start: index, end };
+  }
+  return undefined;
+}
+
+function splitLines(content: string): string[] {
+  return content.replace(/\r\n/g, '\n').replace(/\n$/, '').split('\n');
+}
+
+function trimFinalNewline(value: string): string {
+  return value.replace(/\n$/, '');
+}
+
+function readLineIndentation(line: string): string {
+  return line.match(/^\s*/)?.[0] ?? '';
+}
+
+function clampLine(value: number, lineCount: number): number {
+  if (!Number.isFinite(value)) return lineCount;
+  return Math.max(0, Math.min(Math.floor(value), lineCount));
+}
+
+function sourceLineIndex(line: number): number {
+  if (!Number.isFinite(line)) return 0;
+  return Math.max(0, Math.floor(line) - 1);
+}
+
+function hashLine(line: string): string {
+  return createHash('sha256').update(line.trim()).digest('hex').slice(0, 12);
+}
+
+function singleLine(value: string): string {
+  return value.replace(/\r?\n/g, ' ').trim();
+}
+
+function safeFileName(value: string): string {
+  return value.replace(/[^A-Za-z0-9_.-]/g, '_');
+}
+
+function encodeFrontMatterValue(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  return String(value);
+}
+
+function decodeFrontMatterValue(value: string): unknown {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  if (/^-?\d+(?:\.\d+)?$/.test(value)) return Number(value);
+  if (value.startsWith('"')) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanValue(value: unknown): boolean | undefined {
+  return typeof value === 'boolean' ? value : undefined;
+}

--- a/extension/src/reviews/reviewRoundTrip.ts
+++ b/extension/src/reviews/reviewRoundTrip.ts
@@ -51,9 +51,20 @@ interface MarkerRecord {
   title: string;
   body: string;
   file: string;
+  /** Zero-based source line that the marker annotates, not the marker line itself. */
   line: number;
   lineHash?: string;
   hasConflict: boolean;
+}
+
+interface MarkerWriteResult {
+  lineHash: string;
+  range?: ReviewSourceRange;
+}
+
+interface LineRange {
+  start: number;
+  end: number;
 }
 
 interface BodyRecord {
@@ -100,14 +111,19 @@ export async function persistReviewSticky(
 ): Promise<LoadedReviewSticky> {
   const review = normalizePersistInput(input);
   const createdAt = review.createdAt ?? new Date().toISOString();
-  const anchor = await hydrateAnchor(workspaceRoot, review.anchor);
-  const withAnchor: PersistReviewStickyInput = { ...review, createdAt, anchor };
-
-  await writeReviewBody(workspaceRoot, withAnchor);
+  let anchor = await hydrateAnchor(workspaceRoot, review.anchor);
 
   if (anchor?.file && anchor.range && isSupportedReviewSource(anchor.file)) {
-    await upsertSourceMarker(workspaceRoot, withAnchor, anchor);
+    const marker = await upsertSourceMarker(workspaceRoot, { ...review, createdAt, anchor }, anchor);
+    anchor = {
+      ...anchor,
+      range: marker.range ?? anchor.range,
+      lineHash: marker.lineHash,
+    };
   }
+
+  const withAnchor: PersistReviewStickyInput = { ...review, createdAt, anchor };
+  await writeReviewBody(workspaceRoot, withAnchor);
 
   return {
     reviewId: withAnchor.reviewId,
@@ -227,12 +243,16 @@ async function upsertSourceMarker(
   workspaceRoot: string,
   review: PersistReviewStickyInput,
   anchor: ReviewAnchor,
-): Promise<void> {
-  if (!anchor.file || !anchor.range) return;
+): Promise<MarkerWriteResult> {
+  if (!anchor.file || !anchor.range) {
+    return { lineHash: anchor.lineHash ?? '' };
+  }
 
   const filePath = resolveWorkspacePath(workspaceRoot, anchor.file);
   const prefix = SUPPORTED_COMMENT_PREFIXES.get(path.extname(filePath));
-  if (!prefix) return;
+  if (!prefix) {
+    return { lineHash: anchor.lineHash ?? '' };
+  }
 
   const content = await fs.readFile(filePath, 'utf8');
   const eol = content.includes('\r\n') ? '\r\n' : '\n';
@@ -249,7 +269,23 @@ async function upsertSourceMarker(
     lines.splice(insertAt, 0, ...markerBlock);
   }
 
+  const markerStart = markerRange?.start ?? insertAt;
+  const anchorLineIndex = markerStart + markerBlock.length;
+  const anchorLine = lines[anchorLineIndex] ?? lines[markerStart] ?? '';
+  const nextStartLine = anchorLineIndex + 1;
+  const lineSpan = Math.max(0, anchor.range.endLine - anchor.range.startLine);
+
   await fs.writeFile(filePath, `${lines.join(eol)}${trailingNewline ? eol : ''}`, 'utf8');
+
+  return {
+    lineHash: hashLine(anchorLine),
+    range: {
+      startLine: nextStartLine,
+      startColumn: anchor.range.startColumn,
+      endLine: nextStartLine + lineSpan,
+      endColumn: anchor.range.endColumn,
+    },
+  };
 }
 
 function buildMarkerBlock(
@@ -343,9 +379,9 @@ async function scanReviewMarkers(workspaceRoot: string): Promise<Map<string, Mar
 
   for (const filePath of files) {
     const content = await fs.readFile(filePath, 'utf8');
-    const hasConflict = CONFLICT_PATTERN.test(content);
     const relativeFile = toWorkspaceRelativePath(workspaceRoot, filePath);
     const lines = splitLines(content);
+    const conflictRanges = findConflictRanges(lines);
 
     for (let index = 0; index < lines.length; index += 1) {
       const match = lines[index].match(MARKER_PATTERN);
@@ -362,14 +398,15 @@ async function scanReviewMarkers(workspaceRoot: string): Promise<Map<string, Mar
         cursor += 1;
       }
 
+      const anchorLineIndex = cursor < lines.length ? cursor : index;
       records.set(reviewId, {
         reviewId,
         title,
         body: bodyLines.join('\n'),
         file: relativeFile,
-        line: index,
-        lineHash: hashLine(lines[cursor] ?? lines[index]),
-        hasConflict,
+        line: anchorLineIndex,
+        lineHash: hashLine(lines[anchorLineIndex] ?? lines[index]),
+        hasConflict: overlapsAnyRange(index, cursor, conflictRanges),
       });
       index = cursor - 1;
     }
@@ -504,6 +541,40 @@ function findMarkerRange(
     return { start: index, end };
   }
   return undefined;
+}
+
+function findConflictRanges(lines: readonly string[]): LineRange[] {
+  const ranges: LineRange[] = [];
+  let start: number | undefined;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (/^<<<<<<<(?:\s|$)/.test(line)) {
+      start = index;
+      continue;
+    }
+
+    if (/^=======(?:\s|$)/.test(line) && start === undefined) {
+      ranges.push({ start: index, end: index + 1 });
+      continue;
+    }
+
+    if (/^>>>>>>>(?:\s|$)/.test(line)) {
+      ranges.push({ start: start ?? index, end: index + 1 });
+      start = undefined;
+    }
+  }
+
+  if (start !== undefined) {
+    ranges.push({ start, end: lines.length });
+  }
+
+  return ranges;
+}
+
+function overlapsAnyRange(start: number, end: number, ranges: readonly LineRange[]): boolean {
+  const rangeEnd = Math.max(start + 1, end);
+  return ranges.some((range) => start < range.end && range.start < rangeEnd);
 }
 
 function splitLines(content: string): string[] {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,15 +33,19 @@ import {
 import type { CallGraphPayload } from './graph/types';
 import {
   commitSticky,
+  createDetachedSticky,
   createStickyForAnchor,
+  listStickyGroups,
   removeSticky,
   updateStickyText,
 } from './sticky/sticky';
-import { isReviewStickyCustomData } from './sticky/types';
+import { isReviewStickyCustomData, type ReviewStickyAnchor, type ReviewStickyRoundTripData } from './sticky/types';
 import {
   getInitialDocumentContent,
+  getInitialReviewStickies,
   saveDocumentContent,
   saveDocumentFile,
+  saveReviewSticky,
   subscribeAnalysisUpdates,
   subscribeDocumentUpdates,
 } from './vscodeBridge';
@@ -86,6 +90,81 @@ function anchorBoxFromElement(
   return { id: String(element.id), x, y, width, height };
 }
 
+function graphNodeIdFromElement(element: ExcalidrawElementStub | undefined): string | undefined {
+  if (!element) return undefined;
+  const data = element.customData;
+  if (data && typeof data === 'object') {
+    const nodeId = (data as { nodeId?: unknown }).nodeId;
+    if (typeof nodeId === 'string' && nodeId.length > 0) return nodeId;
+  }
+  if (typeof element.id === 'string' && element.id.startsWith('auto-node-')) {
+    return element.id.replace(/^auto-node-/, '');
+  }
+  return undefined;
+}
+
+function findAnchorBoxForReview(
+  elements: readonly ExcalidrawElementStub[],
+  anchor: ReviewStickyAnchor | undefined,
+  analysisNodes: readonly (CallGraphPayload['nodes'][number])[] = [],
+): ReturnType<typeof anchorBoxFromElement> {
+  let nodeId = anchor?.nodeId ?? anchor?.symbolId;
+  if (!nodeId && anchor?.file && anchor.range) {
+    const targetFile = normalizeFilePath(anchor.file);
+    const node = analysisNodes.find((candidate) => {
+      const candidateFile = normalizeFilePath(candidate.file);
+      return (
+        (candidateFile === targetFile || candidateFile.endsWith(`/${targetFile}`)) &&
+        candidate.range.startLine === anchor.range?.startLine
+      );
+    });
+    nodeId = node?.id;
+  }
+  if (!nodeId) return null;
+
+  const byId = anchorBoxFromElement(elements.find((element) => element.id === `auto-node-${nodeId}`));
+  if (byId) return byId;
+
+  const byCustomData = elements.find((element) => graphNodeIdFromElement(element) === nodeId);
+  return anchorBoxFromElement(byCustomData);
+}
+
+function normalizeFilePath(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+function readReviewAnchorFromScene(
+  elements: readonly ExcalidrawElementStub[],
+  analysisNodes: readonly (CallGraphPayload['nodes'][number])[],
+  reviewId: string,
+): ReviewStickyAnchor | undefined {
+  const group = listStickyGroups(elements).find((item) => item.reviewId === reviewId);
+  const bodyData = group?.body?.customData;
+  const connectorData = group?.connector?.customData;
+  const stickyData = isReviewStickyCustomData(bodyData)
+    ? bodyData
+    : isReviewStickyCustomData(connectorData)
+      ? connectorData
+      : undefined;
+  const anchorElementId = stickyData?.anchorElementId;
+  const anchorElement = anchorElementId
+    ? elements.find((element) => element.id === anchorElementId)
+    : undefined;
+  const nodeId = graphNodeIdFromElement(anchorElement);
+  const graphNode = nodeId ? analysisNodes.find((node) => node.id === nodeId) : undefined;
+
+  if (graphNode) {
+    return {
+      nodeId: graphNode.id,
+      symbolId: graphNode.id,
+      file: graphNode.file,
+      range: graphNode.range,
+    };
+  }
+
+  return stickyData?.anchor;
+}
+
 export default function App() {
   const initialDocument = useMemo(readInitialDocument, []);
   const initialContent = useMemo(() => serializeCanvasDocument(initialDocument), [initialDocument]);
@@ -94,6 +173,8 @@ export default function App() {
   const apiRef = useRef<ExcalidrawImperativeAPI | null>(null);
   const cardsRef = useRef<CodeCard[]>([]);
   const latestContentRef = useRef<string>(initialContent);
+  const latestAnalysisNodesRef = useRef<CallGraphPayload['nodes']>([]);
+  const initialReviewStickiesRef = useRef<ReviewStickyRoundTripData[]>(getInitialReviewStickies());
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [autoLocked, setAutoLocked] = useState(true);
   const [selectedGraphNodeId, setSelectedGraphNodeId] = useState<string | null>(null);
@@ -116,6 +197,60 @@ export default function App() {
     return () => window.removeEventListener('keydown', handleSaveShortcut);
   }, []);
 
+  const mergeInitialReviewStickies = useCallback(
+    (elements: readonly ExcalidrawElementStub[]): ExcalidrawElementStub[] => {
+      const reviews = initialReviewStickiesRef.current;
+      if (reviews.length === 0) return [...elements];
+
+      const existingGroups = new Map(listStickyGroups(elements).map((group) => [group.reviewId, group]));
+      let next = [...elements];
+      let detachedIndex = 0;
+
+      for (const review of reviews) {
+        const existingGroup = existingGroups.get(review.reviewId);
+        const anchorBox = findAnchorBoxForReview(next, review.anchor, latestAnalysisNodesRef.current);
+        if (existingGroup && (!anchorBox || existingGroup.connector)) continue;
+
+        const status = anchorBox
+          ? review.status ?? 'active'
+          : review.status === 'active' || !review.status
+            ? 'anchor-lost'
+            : review.status;
+        const warning = anchorBox
+          ? review.warning
+          : review.warning ?? 'Source symbol anchor was not found on this canvas.';
+        const restored = anchorBox
+          ? createStickyForAnchor(anchorBox, {
+              ...review,
+              draft: false,
+              status,
+              warning,
+              source: review.source ?? 'roundtrip',
+            }).elements
+          : createDetachedSticky({
+              ...review,
+              draft: false,
+              status,
+              warning,
+              source: review.source ?? 'roundtrip',
+              x: 80 + detachedIndex * 24,
+              y: 80 + detachedIndex * 24,
+            }).elements;
+
+        if (existingGroup) {
+          next = removeSticky(next, review.reviewId);
+        }
+        detachedIndex += anchorBox ? 0 : 1;
+        next = [...next, ...restored];
+        const restoredGroup = listStickyGroups(restored)[0];
+        if (restoredGroup) existingGroups.set(review.reviewId, restoredGroup);
+      }
+
+      return next;
+    },
+    [],
+  );
+
   const applyDocumentContent = useCallback((content: string) => {
     const document = parseCanvasDocumentContent(content);
     const initialData = toExcalidrawInitialData(document);
@@ -130,20 +265,22 @@ export default function App() {
     if (files.length > 0) {
       api.addFiles(files);
     }
+    const elements = mergeInitialReviewStickies(initialData.elements as unknown as ExcalidrawElementStub[]);
     api.updateScene({
-      elements: initialData.elements as unknown as ExcalidrawElement[],
+      elements: elements as unknown as ExcalidrawElement[],
       appState: {
         ...(initialData.appState as unknown as AppState),
         collaborators: new Map(),
       },
       captureUpdate: CaptureUpdateAction.NEVER,
     });
-  }, []);
+  }, [mergeInitialReviewStickies]);
 
   useEffect(() => subscribeDocumentUpdates(applyDocumentContent), [applyDocumentContent]);
 
   const applyAnalysis = useCallback(
     (payload: CallGraphPayload) => {
+      latestAnalysisNodesRef.current = payload.nodes;
       const api = apiRef.current;
       if (!api) return;
 
@@ -161,13 +298,13 @@ export default function App() {
         { locked: autoLocked, nodeGroupIds: existingNodeGroupIds },
       );
 
-      const next = [...autoElements, ...userOnly, ...stickyElements];
+      const next = mergeInitialReviewStickies([...autoElements, ...userOnly, ...stickyElements]);
       api.updateScene({
         elements: next as unknown as ExcalidrawElement[],
         captureUpdate: CaptureUpdateAction.IMMEDIATELY,
       });
     },
-    [autoLocked],
+    [autoLocked, mergeInitialReviewStickies],
   );
 
   useEffect(() => subscribeAnalysisUpdates(applyAnalysis), [applyAnalysis]);
@@ -190,7 +327,15 @@ export default function App() {
 
   const handleExcalidrawAPI = useCallback((api: ExcalidrawImperativeAPI) => {
     apiRef.current = api;
-  }, []);
+    const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+    const restored = mergeInitialReviewStickies(current);
+    if (restored.length !== current.length) {
+      api.updateScene({
+        elements: restored as unknown as ExcalidrawElement[],
+        captureUpdate: CaptureUpdateAction.NEVER,
+      });
+    }
+  }, [mergeInitialReviewStickies]);
 
   const handleChange = useCallback<ExcalidrawChangeHandler>(
     (elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {
@@ -266,10 +411,22 @@ export default function App() {
       : getSelectedGraphNode(current, api.getAppState().selectedElementIds);
     const anchor = anchorBoxFromElement(selectedNode);
     if (!anchor) return;
+    const nodeId = graphNodeIdFromElement(selectedNode);
+    const graphNode = nodeId ? latestAnalysisNodesRef.current.find((node) => node.id === nodeId) : undefined;
+    const reviewAnchor = graphNode
+      ? {
+          nodeId: graphNode.id,
+          symbolId: graphNode.id,
+          file: graphNode.file,
+          range: graphNode.range,
+        }
+      : undefined;
 
     const { reviewId, elements: stickyElements } = createStickyForAnchor(anchor, {
       title: '',
       body: '',
+      anchor: reviewAnchor,
+      source: 'canvas',
     });
     api.updateScene({
       elements: [...current, ...stickyElements] as unknown as ExcalidrawElement[],
@@ -318,11 +475,27 @@ export default function App() {
       const api = apiRef.current;
       if (api) {
         const current = api.getSceneElements() as unknown as ExcalidrawElementStub[];
+        const anchor = readReviewAnchorFromScene(current, latestAnalysisNodesRef.current, prev.reviewId);
         const withText = updateStickyText(current, prev.reviewId, prev.title, prev.body);
-        const committed = commitSticky(withText, prev.reviewId);
+        const committed = commitSticky(withText, prev.reviewId, {
+          title: prev.title,
+          body: prev.body,
+          anchor,
+          status: 'active',
+          source: 'canvas',
+        });
         api.updateScene({
           elements: committed as unknown as ExcalidrawElement[],
           captureUpdate: CaptureUpdateAction.IMMEDIATELY,
+        });
+        saveReviewSticky({
+          reviewId: prev.reviewId,
+          title: prev.title,
+          body: prev.body,
+          draft: false,
+          anchor,
+          status: 'active',
+          source: 'canvas',
         });
       }
       return null;

--- a/frontend/src/sticky/sticky.test.ts
+++ b/frontend/src/sticky/sticky.test.ts
@@ -82,6 +82,7 @@ beforeEach(() => {
 
 import {
   commitSticky,
+  createDetachedSticky,
   createStickyForAnchor,
   getStickyReviewId,
   isStickyElement,
@@ -97,7 +98,16 @@ const anchor: AnchorBox = { id: 'auto-node-foo', x: 0, y: 0, width: 200, height:
 
 describe('createStickyForAnchor', () => {
   it('produces a body rectangle and a connector arrow tagged as reviewSticky', () => {
-    const result = createStickyForAnchor(anchor, { reviewId: 'r1', title: 'hi', body: 'note' });
+    const result = createStickyForAnchor(anchor, {
+      reviewId: 'r1',
+      title: 'hi',
+      body: 'note',
+      anchor: {
+        nodeId: 'src/a.ts#foo',
+        file: 'src/a.ts',
+        range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 },
+      },
+    });
     const rects = result.elements.filter((e) => e.type === 'rectangle');
     const arrows = result.elements.filter((e) => e.type === 'arrow');
     expect(rects).toHaveLength(1);
@@ -108,6 +118,9 @@ describe('createStickyForAnchor', () => {
       expect(data.reviewId).toBe('r1');
       expect(data.draft).toBe(true);
       expect(data.anchorElementId).toBe(anchor.id);
+      expect(data.title).toBe('hi');
+      expect(data.body).toBe('note');
+      expect(data.anchor?.file).toBe('src/a.ts');
     }
   });
 
@@ -161,10 +174,12 @@ describe('createStickyForAnchor', () => {
 describe('commitSticky', () => {
   it('clears draft on every element of the matching reviewId', () => {
     const { elements } = createStickyForAnchor(anchor, { reviewId: 'r6', title: 't', body: 'b' });
-    const committed = commitSticky(elements, 'r6');
+    const committed = commitSticky(elements, 'r6', { status: 'active', source: 'both' });
     for (const element of committed) {
       const data = element.customData as ReviewStickyCustomData;
       expect(data.draft).toBe(false);
+      expect(data.status).toBe('active');
+      expect(data.source).toBe('both');
     }
   });
 
@@ -203,6 +218,11 @@ describe('updateStickyText', () => {
     const label = updated.find((e) => e.type === 'text');
     expect(label?.text).toBe('NEW\n\nBODY2');
     expect(label?.originalText).toBe('NEW\n\nBODY2');
+    for (const element of updated) {
+      const data = element.customData as ReviewStickyCustomData;
+      expect(data.title).toBe('NEW');
+      expect(data.body).toBe('BODY2');
+    }
   });
 
   it('still produces a label element when sticky was created with empty text', () => {
@@ -220,6 +240,29 @@ describe('updateStickyText', () => {
     const labelAfter = updated.find((e) => e.type === 'text');
     expect(labelAfter?.text).toBe('제목\n\n본문');
     expect(labelAfter?.originalText).toBe('제목\n\n본문');
+  });
+});
+
+describe('createDetachedSticky', () => {
+  it('restores a persisted sticky without creating a connector', () => {
+    const { elements, connectorElementId } = createDetachedSticky({
+      reviewId: 'detached',
+      title: 'Orphan',
+      body: 'Body',
+      status: 'orphan-body',
+      source: 'body',
+      draft: false,
+    });
+
+    expect(connectorElementId).toBeUndefined();
+    expect(elements.some((element) => element.type === 'arrow')).toBe(false);
+    expect(elements.some((element) => element.type === 'rectangle')).toBe(true);
+    for (const element of elements) {
+      const data = element.customData as ReviewStickyCustomData;
+      expect(data.reviewId).toBe('detached');
+      expect(data.status).toBe('orphan-body');
+      expect(data.draft).toBe(false);
+    }
   });
 });
 

--- a/frontend/src/sticky/sticky.ts
+++ b/frontend/src/sticky/sticky.ts
@@ -4,7 +4,14 @@ import type { ExcalidrawElementSkeleton } from '@excalidraw/excalidraw/data/tran
 import { ulid } from 'ulid';
 
 import type { ExcalidrawElementStub } from '../types/CanvasDocument';
-import { STICKY_ELEMENT_KIND, isReviewStickyCustomData, type ReviewStickyCustomData } from './types';
+import {
+  STICKY_ELEMENT_KIND,
+  isReviewStickyCustomData,
+  type ReviewStickyAnchor,
+  type ReviewStickyCustomData,
+  type ReviewStickyRoundTripData,
+  type ReviewStickyStatus,
+} from './types';
 
 export const STICKY_WIDTH = 200;
 export const STICKY_HEIGHT = 120;
@@ -27,13 +34,20 @@ export interface CreateStickyOptions {
   reviewId?: string;
   title?: string;
   body?: string;
+  draft?: boolean;
+  anchor?: ReviewStickyAnchor;
+  status?: ReviewStickyStatus;
+  warning?: string;
+  source?: ReviewStickyRoundTripData['source'];
+  x?: number;
+  y?: number;
 }
 
 export interface CreateStickyResult {
   reviewId: string;
   elements: ExcalidrawElementStub[];
   bodyElementId: string;
-  connectorElementId: string;
+  connectorElementId?: string;
 }
 
 function bodyElementId(reviewId: string): string {
@@ -69,23 +83,12 @@ export function createStickyForAnchor(
   options: CreateStickyOptions = {},
 ): CreateStickyResult {
   const reviewId = options.reviewId ?? ulid();
-  const stickyX = anchor.x + anchor.width + STICKY_OFFSET_X;
-  const stickyY = anchor.y + STICKY_OFFSET_Y;
+  const stickyX = options.x ?? anchor.x + anchor.width + STICKY_OFFSET_X;
+  const stickyY = options.y ?? anchor.y + STICKY_OFFSET_Y;
+  const draft = options.draft ?? true;
 
-  const body: ReviewStickyCustomData = {
-    kind: STICKY_ELEMENT_KIND,
-    reviewId,
-    draft: true,
-    anchorElementId: anchor.id,
-    role: 'body',
-  };
-  const connector: ReviewStickyCustomData = {
-    kind: STICKY_ELEMENT_KIND,
-    reviewId,
-    draft: true,
-    anchorElementId: anchor.id,
-    role: 'connector',
-  };
+  const body = createStickyCustomData(reviewId, 'body', anchor.id, { ...options, draft });
+  const connector = createStickyCustomData(reviewId, 'connector', anchor.id, { ...options, draft });
 
   const labelText = defaultText(options.title ?? '', options.body ?? '') || EMPTY_LABEL_PLACEHOLDER;
 
@@ -130,7 +133,14 @@ export function createStickyForAnchor(
   }) as unknown as ExcalidrawElement[];
 
   // Stamp customData on bound label so it travels with the sticky.
-  const stubs = built.map((element) => stampStickyCustomData(element as unknown as ExcalidrawElementStub, reviewId, anchor.id));
+  const stubs = built.map((element) =>
+    stampStickyCustomData(
+      element as unknown as ExcalidrawElementStub,
+      reviewId,
+      anchor.id,
+      { ...options, draft },
+    ),
+  );
 
   return {
     reviewId,
@@ -140,10 +150,83 @@ export function createStickyForAnchor(
   };
 }
 
+export function createDetachedSticky(options: CreateStickyOptions = {}): CreateStickyResult {
+  const reviewId = options.reviewId ?? ulid();
+  const stickyX = options.x ?? 80;
+  const stickyY = options.y ?? 80;
+  const draft = options.draft ?? false;
+  const labelText = defaultText(options.title ?? '', options.body ?? '') || EMPTY_LABEL_PLACEHOLDER;
+
+  const skeletons: ExcalidrawElementSkeleton[] = [
+    {
+      type: 'rectangle',
+      id: bodyElementId(reviewId),
+      x: stickyX,
+      y: stickyY,
+      width: STICKY_WIDTH,
+      height: STICKY_HEIGHT,
+      backgroundColor: STICKY_BG,
+      strokeColor: STICKY_STROKE,
+      fillStyle: 'solid',
+      roundness: { type: 3 },
+      locked: false,
+      customData: createStickyCustomData(reviewId, 'body', undefined, { ...options, draft }),
+      label: {
+        text: labelText,
+        fontSize: 14,
+        strokeColor: STICKY_STROKE,
+        textAlign: 'left',
+        verticalAlign: 'top',
+      },
+    },
+  ];
+
+  const built = convertToExcalidrawElements(skeletons, {
+    regenerateIds: false,
+  }) as unknown as ExcalidrawElement[];
+
+  const stubs = built.map((element) =>
+    stampStickyCustomData(
+      element as unknown as ExcalidrawElementStub,
+      reviewId,
+      undefined,
+      { ...options, draft },
+    ),
+  );
+
+  return {
+    reviewId,
+    elements: stubs,
+    bodyElementId: bodyElementId(reviewId),
+  };
+}
+
+function createStickyCustomData(
+  reviewId: string,
+  role: ReviewStickyCustomData['role'],
+  anchorElementId: string | undefined,
+  options: CreateStickyOptions,
+): ReviewStickyCustomData {
+  return {
+    kind: STICKY_ELEMENT_KIND,
+    reviewId,
+    draft: options.draft,
+    anchorElementId,
+    anchor: options.anchor,
+    title: options.title,
+    body: options.body,
+    status: options.status,
+    source: options.source,
+    warning: options.warning,
+    role,
+  };
+}
+
 function stampStickyCustomData(
   element: ExcalidrawElementStub,
   reviewId: string,
-  anchorElementId: string,
+  anchorElementId: string | undefined,
+  options: CreateStickyOptions,
 ): ExcalidrawElementStub {
   const existing = element.customData as ReviewStickyCustomData | undefined;
   if (existing?.kind === STICKY_ELEMENT_KIND) return element;
@@ -157,11 +240,7 @@ function stampStickyCustomData(
     return {
       ...element,
       customData: {
-        kind: STICKY_ELEMENT_KIND,
-        reviewId,
-        draft: true,
-        anchorElementId,
-        role: 'body',
+        ...createStickyCustomData(reviewId, 'body', anchorElementId, options),
       } satisfies ReviewStickyCustomData,
     };
   }
@@ -185,13 +264,17 @@ export function getStickyReviewId(element: ExcalidrawElementStub): string | unde
 export function commitSticky(
   elements: readonly ExcalidrawElementStub[],
   reviewId: string,
+  metadata: Partial<Pick<
+    ReviewStickyCustomData,
+    'title' | 'body' | 'anchor' | 'status' | 'source' | 'warning'
+  >> = {},
 ): ExcalidrawElementStub[] {
   return elements.map((element) => {
     const data = element.customData;
     if (!isReviewStickyCustomData(data) || data.reviewId !== reviewId) return element;
     return {
       ...element,
-      customData: { ...data, draft: false } satisfies ReviewStickyCustomData,
+      customData: { ...data, ...metadata, draft: false } satisfies ReviewStickyCustomData,
     };
   });
 }
@@ -225,9 +308,16 @@ export function updateStickyText(
   return elements.map((element) => {
     const data = element.customData;
     if (!isReviewStickyCustomData(data) || data.reviewId !== reviewId) return element;
-    if (element.type !== 'text') return element;
+    const nextCustomData = { ...data, title, body } satisfies ReviewStickyCustomData;
+    if (element.type !== 'text') {
+      return {
+        ...element,
+        customData: nextCustomData,
+      };
+    }
     return {
       ...element,
+      customData: nextCustomData,
       text,
       originalText: text,
     };

--- a/frontend/src/sticky/types.ts
+++ b/frontend/src/sticky/types.ts
@@ -1,4 +1,5 @@
 import { REVIEW_STICKY_KIND } from '../graph/types';
+import type { GraphSourceRange } from '../graph/types';
 import { isNonEmptyString, isRecord } from '../types/utils';
 
 /**
@@ -8,6 +9,33 @@ import { isNonEmptyString, isRecord } from '../types/utils';
  */
 export const STICKY_ELEMENT_KIND = REVIEW_STICKY_KIND;
 
+export type ReviewStickyStatus =
+  | 'active'
+  | 'orphan-marker'
+  | 'orphan-body'
+  | 'merge-conflict'
+  | 'anchor-lost';
+
+export interface ReviewStickyAnchor {
+  nodeId?: string;
+  symbolId?: string;
+  file?: string;
+  range?: GraphSourceRange;
+  lineHash?: string;
+}
+
+export interface ReviewStickyRoundTripData {
+  reviewId: string;
+  title: string;
+  body: string;
+  draft?: boolean;
+  createdAt?: string;
+  anchor?: ReviewStickyAnchor;
+  status?: ReviewStickyStatus;
+  source?: 'marker' | 'body' | 'both' | 'canvas' | 'roundtrip';
+  warning?: string;
+}
+
 export interface ReviewStickyCustomData {
   kind: typeof STICKY_ELEMENT_KIND;
   /** ULID assigned at creation; stable across renames and re-renders. */
@@ -16,6 +44,15 @@ export interface ReviewStickyCustomData {
   draft?: boolean;
   /** Element id of the anchor (auto-generated graph node) the sticky is attached to. */
   anchorElementId?: string;
+  /** Source/symbol anchor used by the extension to restore the sticky later. */
+  anchor?: ReviewStickyAnchor;
+  /** Last committed title/body pair mirrored into source markers and markdown. */
+  title?: string;
+  body?: string;
+  /** Round-trip reconciliation status from extension-side load. */
+  status?: ReviewStickyStatus;
+  source?: ReviewStickyRoundTripData['source'];
+  warning?: string;
   /**
    * Distinguishes the sticky body element from its anchor connector.
    * Both share the same reviewId so cancellation/save can clean them up together.
@@ -28,5 +65,13 @@ export function isReviewStickyCustomData(value: unknown): value is ReviewStickyC
   if (value.kind !== STICKY_ELEMENT_KIND) return false;
   if (!isNonEmptyString(value.reviewId)) return false;
   if (value.role !== 'body' && value.role !== 'connector') return false;
+  return true;
+}
+
+export function isReviewStickyRoundTripData(value: unknown): value is ReviewStickyRoundTripData {
+  if (!isRecord(value)) return false;
+  if (!isNonEmptyString(value.reviewId)) return false;
+  if (typeof value.title !== 'string') return false;
+  if (typeof value.body !== 'string') return false;
   return true;
 }

--- a/frontend/src/vscodeBridge.test.ts
+++ b/frontend/src/vscodeBridge.test.ts
@@ -1,7 +1,9 @@
 import {
   getInitialDocumentContent,
+  getInitialReviewStickies,
   saveDocumentContent,
   saveDocumentFile,
+  saveReviewSticky,
   subscribeDocumentUpdates,
 } from './vscodeBridge';
 
@@ -16,9 +18,11 @@ describe('vscodeBridge', () => {
 
   afterEach(() => {
     delete window.__codetrace_initialContent;
+    delete window.__codetrace_initialReviewStickies;
     delete window.__codetrace_onUpdate;
     delete window.__codetrace_save;
     delete window.__codetrace_saveFile;
+    delete window.__codetrace_saveReviewSticky;
     delete (globalThis as { window?: unknown }).window;
   });
 
@@ -26,6 +30,16 @@ describe('vscodeBridge', () => {
     window.__codetrace_initialContent = '{"version":1}';
 
     expect(getInitialDocumentContent()).toBe('{"version":1}');
+  });
+
+  it('filters initial review stickies from the webview bootstrap', () => {
+    window.__codetrace_initialReviewStickies = [
+      { reviewId: 'r1', title: 'Title', body: 'Body' },
+      { reviewId: '', title: 'Nope', body: 'Body' },
+      { reviewId: 'r2', title: 'Missing body' },
+    ];
+
+    expect(getInitialReviewStickies()).toEqual([{ reviewId: 'r1', title: 'Title', body: 'Body' }]);
   });
 
   it('subscribes and restores the previous update handler', () => {
@@ -58,5 +72,14 @@ describe('vscodeBridge', () => {
     saveDocumentFile('content');
 
     expect(saveFile).toHaveBeenCalledWith('content');
+  });
+
+  it('posts review sticky payloads to the extension save hook', () => {
+    const saveReview = jest.fn();
+    window.__codetrace_saveReviewSticky = saveReview;
+
+    saveReviewSticky({ reviewId: 'r1', title: 'Title', body: 'Body' });
+
+    expect(saveReview).toHaveBeenCalledWith({ reviewId: 'r1', title: 'Title', body: 'Body' });
   });
 });

--- a/frontend/src/vscodeBridge.ts
+++ b/frontend/src/vscodeBridge.ts
@@ -1,20 +1,30 @@
 import type { CallGraphPayload } from './graph/types';
+import { isReviewStickyRoundTripData, type ReviewStickyRoundTripData } from './sticky/types';
 
 export type CodetraceUpdateHandler = (content: string) => void;
 export type CodetraceAnalysisHandler = (payload: CallGraphPayload) => void;
+export type CodetraceReviewStickySaveHandler = (review: ReviewStickyRoundTripData) => void;
 
 declare global {
   interface Window {
     __codetrace_initialContent?: string;
+    __codetrace_initialReviewStickies?: unknown[];
     __codetrace_onUpdate?: CodetraceUpdateHandler;
     __codetrace_onAnalysis?: CodetraceAnalysisHandler;
     __codetrace_save?: (content: string) => void;
     __codetrace_saveFile?: (content: string) => void;
+    __codetrace_saveReviewSticky?: CodetraceReviewStickySaveHandler;
   }
 }
 
 export function getInitialDocumentContent(): string | undefined {
   return window.__codetrace_initialContent;
+}
+
+export function getInitialReviewStickies(): ReviewStickyRoundTripData[] {
+  const raw = window.__codetrace_initialReviewStickies;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(isReviewStickyRoundTripData);
 }
 
 export function subscribeDocumentUpdates(handler: CodetraceUpdateHandler): () => void {
@@ -41,4 +51,8 @@ export function saveDocumentContent(content: string): void {
 
 export function saveDocumentFile(content: string): void {
   window.__codetrace_saveFile?.(content);
+}
+
+export function saveReviewSticky(review: ReviewStickyRoundTripData): void {
+  window.__codetrace_saveReviewSticky?.(review);
 }


### PR DESCRIPTION
Closes #71

Summary:
- Persist review stickies as source marker comments plus .codetrace/reviews markdown bodies.
- Bootstrap saved review stickies back into the webview and restore active/orphan/conflict states.
- Carry sticky title/body/anchor/status metadata through canvas elements and extension bridge.

Verification:
- npm.cmd exec --workspace=extension -- jest --config jest.config.cjs --runInBand src/reviews/reviewRoundTrip.test.ts
- npm.cmd exec --workspace=extension -- tsc -p ./ --noEmit
- npm.cmd run build --workspace=extension
- npm.cmd test --workspace=frontend -- --runInBand
- npm.cmd exec --workspace=frontend -- tsc --noEmit
- npm.cmd run build --workspace=frontend

Note: npm.cmd test --workspace=extension reaches vscode-test but fails while refreshing the local .vscode-test Insiders archive because node_modules.asar is locked with EBUSY.