### PR TITLE
fix: eliminate arrow z-order regression and pan/zoom jank

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -271,6 +271,8 @@ function removeGraphNodeElements(
   });
 }
 
+function noop() {}
+
 export default function App() {
   const initialDocument = useMemo(readInitialDocument, []);
   const initialContent = useMemo(() => serializeCanvasDocument(initialDocument), [initialDocument]);
@@ -282,9 +284,12 @@ export default function App() {
   const latestAnalysisEdgesRef = useRef<CallGraphPayload['edges']>([]);
   const initialReviewStickiesRef = useRef<ReviewStickyRoundTripData[]>(getInitialReviewStickies());
   const previousSceneElementsRef = useRef<ExcalidrawElementStub[]>(initialData.elements as unknown as ExcalidrawElementStub[]);
+  const previousAppStateRef = useRef<AppState | null>(null);
   const removedGraphNodeIdsRef = useRef<Set<string>>(new Set());
   const suppressDeletionDetectionRef = useRef(false);
   const pendingDeletionRef = useRef<PendingNodeDeletionState | null>(null);
+  const saveDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSaveCallbackRef = useRef<() => void>(noop);
   const queuedAnalysisPayloadRef = useRef<CallGraphPayload | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [autoLocked, setAutoLocked] = useState(true);
@@ -492,10 +497,42 @@ export default function App() {
 
   const handleChange = useCallback<ExcalidrawChangeHandler>(
     (elements: readonly ExcalidrawElement[], appState: AppState, files: BinaryFiles) => {
+      const prevApp = previousAppStateRef.current;
+      const prevElements = previousSceneElementsRef.current;
+
+      // Pure pan/zoom frames: only viewport changed, no element or selection diff.
+      // Skip the heavy synchronous prefix entirely to keep panning smooth.
+      // selectedElementIds is a new object every frame; compare by stable string key.
+      const selIds = appState.selectedElementIds;
+      const prevSelIds = prevApp?.selectedElementIds;
+      const selChanged =
+        prevSelIds === undefined ||
+        Object.keys(selIds).length !== Object.keys(prevSelIds).length ||
+        Object.keys(selIds).some((k) => !prevSelIds[k]);
+      if (
+        prevApp !== null &&
+        elements.length === prevElements.length &&
+        !selChanged &&
+        (appState.scrollX !== prevApp.scrollX ||
+          appState.scrollY !== prevApp.scrollY ||
+          appState.zoom.value !== prevApp.zoom.value) &&
+        appState.editingTextElement === prevApp.editingTextElement
+      ) {
+        // Defer any pending save so JSON.stringify doesn't fire mid-pan.
+        if (saveDebounceTimerRef.current !== null) {
+          clearTimeout(saveDebounceTimerRef.current);
+          saveDebounceTimerRef.current = setTimeout(pendingSaveCallbackRef.current, 200);
+        }
+        previousAppStateRef.current = appState;
+        return;
+      }
+      previousAppStateRef.current = appState;
+
       const normalized = normalizeUserElements(elements as unknown as ExcalidrawElementStub[]);
       const sceneElements = normalized.elements;
       const previousElements = previousSceneElementsRef.current;
 
+      // Selection update is cheap — always run it.
       setSelectedGraphNodeId(getSelectedGraphNode(sceneElements, appState.selectedElementIds)?.id ?? null);
 
       if (normalized.changed) {
@@ -505,6 +542,8 @@ export default function App() {
         });
       }
 
+      // Deletion detection must run immediately so the undo snapshot is taken
+      // before the deleted element is gone from the array.
       if (suppressDeletionDetectionRef.current) {
         suppressDeletionDetectionRef.current = false;
       } else if (!pendingDeletionRef.current) {
@@ -560,21 +599,33 @@ export default function App() {
         }
       }
 
-      const document = createCanvasDocumentFromScene({
-        elements: sceneElements as unknown as ExcalidrawElementStub[],
-        appState: appState as unknown as Record<string, unknown>,
-        files: files as unknown as Record<string, unknown>,
-      });
-      const content = serializeCanvasDocument(document);
-
-      if (content === latestContentRef.current) {
-        previousSceneElementsRef.current = sceneElements as unknown as ExcalidrawElementStub[];
-        return;
-      }
-
-      latestContentRef.current = content;
       previousSceneElementsRef.current = sceneElements as unknown as ExcalidrawElementStub[];
-      saveDocumentContent(content);
+
+      // Debounce the expensive serialize + save path so that rapid pan/zoom/
+      // selection changes (which fire onChange every frame) don't block the
+      // render thread with JSON.stringify on every tick.
+      if (saveDebounceTimerRef.current !== null) {
+        clearTimeout(saveDebounceTimerRef.current);
+      }
+      const capturedElements = sceneElements;
+      const capturedAppState = appState;
+      const capturedFiles = files;
+      const doSave = () => {
+        saveDebounceTimerRef.current = null;
+        pendingSaveCallbackRef.current = noop;
+        const document = createCanvasDocumentFromScene({
+          elements: capturedElements as unknown as ExcalidrawElementStub[],
+          appState: capturedAppState as unknown as Record<string, unknown>,
+          files: capturedFiles as unknown as Record<string, unknown>,
+          cards: cardsRef.current,
+        });
+        const content = serializeCanvasDocument(document);
+        if (content === latestContentRef.current) return;
+        latestContentRef.current = content;
+        saveDocumentContent(content);
+      };
+      pendingSaveCallbackRef.current = doSave;
+      saveDebounceTimerRef.current = setTimeout(doSave, 200);
     },
     [],
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -617,7 +617,6 @@ export default function App() {
           elements: capturedElements as unknown as ExcalidrawElementStub[],
           appState: capturedAppState as unknown as Record<string, unknown>,
           files: capturedFiles as unknown as Record<string, unknown>,
-          cards: cardsRef.current,
         });
         const content = serializeCanvasDocument(document);
         if (content === latestContentRef.current) return;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -273,6 +273,22 @@ function removeGraphNodeElements(
 
 function noop() {}
 
+/** Returns true when a connector arrow still has Excalidraw's placeholder geometry
+ * (x=0, y=0, height=0, two-point horizontal line). These connectors were never
+ * anchored by anchorStickyConnector and need to be recreated. */
+function isPlaceholderConnector(connector: ExcalidrawElementStub): boolean {
+  const points = connector.points as [number, number][] | undefined;
+  return (
+    connector.x === 0 &&
+    connector.y === 0 &&
+    (connector.height === 0 || connector.height === undefined) &&
+    Array.isArray(points) &&
+    points.length === 2 &&
+    points[0][1] === 0 &&
+    points[1][1] === 0
+  );
+}
+
 export default function App() {
   const initialDocument = useMemo(readInitialDocument, []);
   const initialContent = useMemo(() => serializeCanvasDocument(initialDocument), [initialDocument]);
@@ -302,6 +318,13 @@ export default function App() {
     const handleSaveShortcut = (event: KeyboardEvent) => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
         event.preventDefault();
+        // Flush any pending debounced save first so latestContentRef is up-to-date
+        // before saveDocumentFile reads it. Without this, a Ctrl+S within the 200ms
+        // debounce window would write the previous content to disk.
+        if (saveDebounceTimerRef.current !== null) {
+          clearTimeout(saveDebounceTimerRef.current);
+          pendingSaveCallbackRef.current();
+        }
         saveDocumentFile(latestContentRef.current);
       }
     };
@@ -322,7 +345,14 @@ export default function App() {
       for (const review of reviews) {
         const existingGroup = existingGroups.get(review.reviewId);
         const anchorBox = findAnchorBoxForReview(next, review.anchor, latestAnalysisNodesRef.current);
-        if (existingGroup && (!anchorBox || existingGroup.connector)) continue;
+        // Skip if the group already exists and has real connector geometry.
+        // A connector with placeholder geometry (height === 0, points length === 2
+        // with x=0/y=0 origin) was never properly anchored — fall through to
+        // recreate it via createStickyForAnchor so the corrected geometry applies.
+        const connectorIsReal =
+          existingGroup?.connector &&
+          !isPlaceholderConnector(existingGroup.connector);
+        if (existingGroup && (!anchorBox || connectorIsReal)) continue;
 
         const status = anchorBox
           ? review.status ?? 'active'
@@ -509,9 +539,20 @@ export default function App() {
         prevSelIds === undefined ||
         Object.keys(selIds).length !== Object.keys(prevSelIds).length ||
         Object.keys(selIds).some((k) => !prevSelIds[k]);
+      // Sum element versions to detect same-length scene mutations (e.g. drag
+      // during auto-scroll where viewport and elements change in the same frame).
+      const elementVersionSum = (elements as unknown as { version?: number }[]).reduce(
+        (sum, el) => sum + (el.version ?? 0),
+        0,
+      );
+      const prevVersionSum = (prevElements as { version?: number }[]).reduce(
+        (sum, el) => sum + (el.version ?? 0),
+        0,
+      );
       if (
         prevApp !== null &&
         elements.length === prevElements.length &&
+        elementVersionSum === prevVersionSum &&
         !selChanged &&
         (appState.scrollX !== prevApp.scrollX ||
           appState.scrollY !== prevApp.scrollY ||

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -395,6 +395,11 @@ export default function App() {
   );
 
   const applyDocumentContent = useCallback((content: string) => {
+    if (saveDebounceTimerRef.current !== null) {
+      clearTimeout(saveDebounceTimerRef.current);
+      saveDebounceTimerRef.current = null;
+      pendingSaveCallbackRef.current = noop;
+    }
     const document = parseCanvasDocumentContent(content);
     const initialData = toExcalidrawInitialData(document);
     const api = apiRef.current;

--- a/frontend/src/graph/converter.test.ts
+++ b/frontend/src/graph/converter.test.ts
@@ -235,8 +235,9 @@ describe('convertGraphToElements', () => {
 
     // Reconstruct absolute coordinates for each point in the polyline.
     const ox = arrow!.x ?? 0;
+    const oy = (arrow as { y?: number }).y ?? 0;
     const pts = (arrow!.points ?? []) as [number, number][];
-    const absPoints = pts.map(([px, py]) => [px + ox, py] as [number, number]);
+    const absPoints = pts.map(([px, py]) => [px + ox, py + oy] as [number, number]);
 
     // Verify no horizontal segment passes through node C's x-range.
     const cLeft = 275;

--- a/frontend/src/graph/converter.test.ts
+++ b/frontend/src/graph/converter.test.ts
@@ -266,6 +266,56 @@ describe('convertGraphToElements', () => {
     }
   });
 
+  it('U-shape fallback does not clip obstacle adjacent to source (#92)', () => {
+    // Regression: U-shape midX1=startRight+gap clips an obstacle that starts
+    // immediately to the right of the source node (preserved/manual position).
+    // Layout: A(0,0) -> B(600,0), obstacle C at x=205 (5px gap from A's right edge).
+    // All 3-segment candidates fail, so the router falls back to U-shape.
+    // The fallback must pick midX1 outside C's x-range, not startRight+gap=212.
+    const threeNodes: GraphNode[] = [
+      { id: 'a', name: 'A', kind: 'function', file: 'a.ts', range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 } },
+      { id: 'b', name: 'B', kind: 'function', file: 'b.ts', range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 } },
+      { id: 'c', name: 'C', kind: 'function', file: 'c.ts', range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 } },
+    ];
+    const positions = new Map([
+      ['a', { x: 0, y: 0 }],
+      ['b', { x: 600, y: 0 }],
+      ['c', { x: 205, y: 0 }],  // adjacent to source right edge (200), forces U-shape
+    ]);
+    const edge: GraphEdge = { from: 'a', to: 'b' };
+    const { elements } = convertGraphToElements(threeNodes, [edge], positions);
+    const arrow = elements.find((e) => e.type === 'arrow') as
+      | { points?: [number, number][]; x?: number; y?: number }
+      | undefined;
+    expect(arrow).toBeDefined();
+
+    const ox = arrow!.x ?? 0;
+    const oy = arrow!.y ?? 0;
+    const pts = (arrow!.points ?? []) as [number, number][];
+    const absPoints = pts.map(([px, py]) => [px + ox, py + oy] as [number, number]);
+
+
+
+    const cLeft = 205;
+    const cRight = cLeft + 200; // NODE_WIDTH
+    const cTop = 0;
+    const cBottom = cTop + 60;  // NODE_HEIGHT
+
+    for (let i = 0; i + 1 < absPoints.length; i++) {
+      const [x1, y1] = absPoints[i];
+      const [x2, y2] = absPoints[i + 1];
+      if (y1 === y2) {
+        const segLeft = Math.min(x1, x2);
+        const segRight = Math.max(x1, x2);
+        expect(segLeft < cRight && segRight > cLeft && y1 > cTop && y1 < cBottom).toBe(false);
+      } else if (x1 === x2) {
+        const segTop = Math.min(y1, y2);
+        const segBottom = Math.max(y1, y2);
+        expect(x1 > cLeft && x1 < cRight && segTop < cBottom && segBottom > cTop).toBe(false);
+      }
+    }
+  });
+
   it('skips edges whose endpoints have no position', () => {
     const orphanEdges: GraphEdge[] = [{ from: 'a', to: 'missing' }];
     const { elements } = convertGraphToElements(sampleNodes, orphanEdges);

--- a/frontend/src/graph/converter.test.ts
+++ b/frontend/src/graph/converter.test.ts
@@ -57,9 +57,18 @@ jest.mock('@excalidraw/excalidraw', () => ({
         const start = (skel as { start?: { id: string }; id: string }).start;
         const end = (skel as { end?: { id: string }; id: string }).end;
         const arrowId = resolveId((skel as { id: string }).id);
+        // Mirror Excalidraw's placeholder geometry on arrow output (#92).
         out.push({
           ...skel,
           id: arrowId,
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 0,
+          points: [
+            [0.5, 0],
+            [99.5, 0],
+          ],
           startBinding: start
             ? { elementId: resolveId(start.id), focus: 0, gap: 0 }
             : undefined,
@@ -177,6 +186,28 @@ describe('convertGraphToElements', () => {
     const endBinding = arrow?.endBinding as { elementId: string };
     expect(startBinding?.elementId).toBe('auto-node-a');
     expect(endBinding?.elementId).toBe('auto-node-b');
+  });
+
+  it('routes arrows as L-shape avoiding node bodies (#92)', () => {
+    // Regression for #92: arrows must not pass through node rectangles on first
+    // render. anchorAutoArrowsToBindings replaces Excalidraw placeholder geometry
+    // ([0.5,0]->[99.5,0]) with orthogonal points clipped to node boundaries.
+    const positions = new Map([
+      ['a', { x: 0, y: 0 }],
+      ['b', { x: 400, y: 200 }],
+    ]);
+    const { elements } = convertGraphToElements(sampleNodes, sampleEdges, positions);
+    const arrow = elements.find((e) => e.type === 'arrow') as
+      | { points?: [number, number][]; startBinding?: { elementId: string }; endBinding?: { elementId: string } }
+      | undefined;
+    expect(arrow).toBeDefined();
+    // Points must be replaced from the placeholder [[0.5,0],[99.5,0]].
+    expect(arrow?.points?.length).toBeGreaterThanOrEqual(2);
+    // First point is always [0, 0] (relative origin = arrow.x, arrow.y).
+    expect(arrow?.points?.[0]).toEqual([0, 0]);
+    // Bindings must still reference the correct node element ids.
+    expect(arrow?.startBinding?.elementId).toBe('auto-node-a');
+    expect(arrow?.endBinding?.elementId).toBe('auto-node-b');
   });
 
   it('skips edges whose endpoints have no position', () => {

--- a/frontend/src/graph/converter.test.ts
+++ b/frontend/src/graph/converter.test.ts
@@ -210,6 +210,61 @@ describe('convertGraphToElements', () => {
     expect(arrow?.endBinding?.elementId).toBe('auto-node-b');
   });
 
+  it('routes around intermediate node bodies including horizontal legs (#92)', () => {
+    // Layout: A(0,0) -> B(600,0), with C(300,0) directly on the L-shape path.
+    // The midX=300 vertical segment would clip C, and the horizontal legs at y=25
+    // would also pass through C. The router must shift midX past C's boundary.
+    const nodeWidth = 150;
+    const nodeHeight = 50;
+    const threeNodes: GraphNode[] = [
+      { id: 'a', name: 'A', kind: 'function', file: 'a.ts', range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 } },
+      { id: 'b', name: 'B', kind: 'function', file: 'b.ts', range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 } },
+      { id: 'c', name: 'C', kind: 'function', file: 'c.ts', range: { startLine: 0, startColumn: 0, endLine: 1, endColumn: 0 } },
+    ];
+    const positions = new Map([
+      ['a', { x: 0, y: 0 }],
+      ['b', { x: 600, y: 0 }],
+      ['c', { x: 275, y: 0 }],  // sits exactly on the default midX=375 path
+    ]);
+    const edge: GraphEdge = { from: 'a', to: 'b' };
+    const { elements } = convertGraphToElements(threeNodes, [edge], positions);
+    const arrow = elements.find((e) => e.type === 'arrow') as
+      | { points?: [number, number][]; x?: number }
+      | undefined;
+    expect(arrow).toBeDefined();
+
+    // Reconstruct absolute coordinates for each point in the polyline.
+    const ox = arrow!.x ?? 0;
+    const pts = (arrow!.points ?? []) as [number, number][];
+    const absPoints = pts.map(([px, py]) => [px + ox, py] as [number, number]);
+
+    // Verify no horizontal segment passes through node C's x-range.
+    const cLeft = 275;
+    const cRight = cLeft + nodeWidth;
+    const cTop = 0;
+    const cBottom = cTop + nodeHeight;
+
+    for (let i = 0; i + 1 < absPoints.length; i++) {
+      const [x1, y1] = absPoints[i];
+      const [x2, y2] = absPoints[i + 1];
+      if (y1 === y2) {
+        // horizontal segment
+        const segLeft = Math.min(x1, x2);
+        const segRight = Math.max(x1, x2);
+        const clipsC =
+          segLeft < cRight && segRight > cLeft && y1 > cTop && y1 < cBottom;
+        expect(clipsC).toBe(false);
+      } else if (x1 === x2) {
+        // vertical segment
+        const segTop = Math.min(y1, y2);
+        const segBottom = Math.max(y1, y2);
+        const clipsC =
+          x1 > cLeft && x1 < cRight && segTop < cBottom && segBottom > cTop;
+        expect(clipsC).toBe(false);
+      }
+    }
+  });
+
   it('skips edges whose endpoints have no position', () => {
     const orphanEdges: GraphEdge[] = [{ from: 'a', to: 'missing' }];
     const { elements } = convertGraphToElements(sampleNodes, orphanEdges);

--- a/frontend/src/graph/converter.ts
+++ b/frontend/src/graph/converter.ts
@@ -215,9 +215,25 @@ function anchorAutoArrowsToBindings(elements: ExcalidrawElement[]): void {
   }
 }
 
+/** Returns true if a horizontal segment from (x1, y) to (x2, y) passes through node. */
+function hSegmentClipsNode(x1: number, x2: number, y: number, node: ExcalidrawElement): boolean {
+  const left = Math.min(x1, x2);
+  const right = Math.max(x1, x2);
+  return left < node.x + node.width && right > node.x && y > node.y && y < node.y + node.height;
+}
+
+/** Returns true if a vertical segment from (x, y1) to (x, y2) passes through node. */
+function vSegmentClipsNode(x: number, y1: number, y2: number, node: ExcalidrawElement): boolean {
+  const top = Math.min(y1, y2);
+  const bottom = Math.max(y1, y2);
+  return x > node.x && x < node.x + node.width && top < node.y + node.height && bottom > node.y;
+}
+
 /** Returns an orthogonal route (absolute coords) from source right edge to target left edge.
  *  Uses 3-segment L-shape: right → mid-x turn → arrive at target left.
- *  If the mid-x vertical segment would clip any intermediate node, offsets it above/below.
+ *  Validates all three segments against intermediate node bodies and offsets midX
+ *  until none of the segments clip a node. Falls back to a straight clipped line
+ *  if no clear orthogonal route can be found.
  */
 function routeAroundNodes(
   start: ExcalidrawElement,
@@ -248,22 +264,34 @@ function routeAroundNodes(
   }
 
   // 3-segment orthogonal route: (startRight, startCy) → (midX, startCy) → (midX, endCy) → (endLeft, endCy)
+  // Collect obstacle nodes (exclude start and end).
+  const obstacles: ExcalidrawElement[] = [];
+  for (const [id, node] of nodesById) {
+    if (id !== startId && id !== endId) obstacles.push(node);
+  }
+
+  const gap = 12;
   let midX = (startRight + endLeft) / 2;
 
-  // Check if the vertical segment at midX clips any other node.
-  const minY = Math.min(startCy, endCy);
-  const maxY = Math.max(startCy, endCy);
-  for (const [id, node] of nodesById) {
-    if (id === startId || id === endId) continue;
-    if (node.x > midX || node.x + node.width < midX) continue;
-    if (node.y > maxY || node.y + node.height < minY) continue;
-    // midX cuts through this node — shift the vertical segment left or right.
-    const gap = 12;
-    const leftX = node.x - gap;
-    const rightX = node.x + node.width + gap;
-    // Pick whichever X detour keeps midX closer to the natural midpoint.
+  // Iteratively shift midX until all three segments clear every obstacle.
+  // Limit iterations to avoid infinite loops on dense graphs.
+  for (let iter = 0; iter < obstacles.length * 2 + 1; iter++) {
+    let clippingNode: ExcalidrawElement | undefined;
+    for (const node of obstacles) {
+      if (
+        vSegmentClipsNode(midX, startCy, endCy, node) ||
+        hSegmentClipsNode(startRight, midX, startCy, node) ||
+        hSegmentClipsNode(midX, endLeft, endCy, node)
+      ) {
+        clippingNode = node;
+        break;
+      }
+    }
+    if (!clippingNode) break;
+
+    const leftX = clippingNode.x - gap;
+    const rightX = clippingNode.x + clippingNode.width + gap;
     midX = Math.abs(leftX - midX) <= Math.abs(rightX - midX) ? leftX : rightX;
-    break;
   }
 
   return [

--- a/frontend/src/graph/converter.ts
+++ b/frontend/src/graph/converter.ts
@@ -270,15 +270,14 @@ function routeAroundNodes(
 
   const gap = 12;
 
-  /** Check if a 3-segment route with the given midX clears all obstacles. */
-  function threeSegClear(mx: number): boolean {
-    for (const node of obstacles) {
-      if (
-        vSegmentClipsNode(mx, startCy, endCy, node) ||
-        hSegmentClipsNode(startRight, mx, startCy, node) ||
-        hSegmentClipsNode(mx, endLeft, endCy, node)
-      ) {
-        return false;
+  /** Check whether every segment of a polyline clears all obstacles. */
+  function polylineClear(points: [number, number][]): boolean {
+    for (let i = 0; i + 1 < points.length; i++) {
+      const [x1, y1] = points[i];
+      const [x2, y2] = points[i + 1];
+      for (const node of obstacles) {
+        if (y1 === y2 && hSegmentClipsNode(x1, x2, y1, node)) return false;
+        if (x1 === x2 && vSegmentClipsNode(x1, y1, y2, node)) return false;
       }
     }
     return true;
@@ -286,25 +285,24 @@ function routeAroundNodes(
 
   // Try candidate midX values: default midpoint, then left/right edges of each obstacle.
   const defaultMidX = (startRight + endLeft) / 2;
-  const candidates: number[] = [defaultMidX];
+  const midXCandidates: number[] = [defaultMidX];
   for (const node of obstacles) {
-    candidates.push(node.x - gap);
-    candidates.push(node.x + node.width + gap);
+    midXCandidates.push(node.x - gap);
+    midXCandidates.push(node.x + node.width + gap);
   }
 
-  for (const mx of candidates) {
-    if (threeSegClear(mx)) {
-      return [
-        [startRight, startCy],
-        [mx, startCy],
-        [mx, endCy],
-        [endLeft, endCy],
-      ];
-    }
+  for (const mx of midXCandidates) {
+    const route: [number, number][] = [
+      [startRight, startCy],
+      [mx, startCy],
+      [mx, endCy],
+      [endLeft, endCy],
+    ];
+    if (polylineClear(route)) return route;
   }
 
-  // No 3-segment route is clear — use 5-segment U-shape going above or below all
-  // obstacle nodes that sit in the horizontal band between startRight and endLeft.
+  // No 3-segment route is clear — use 5-segment U-shape going above or below obstacles.
+  // Both midX1 and midX2 are chosen from safe candidates (obstacle edges), not fixed offsets.
   const bandObstacles = obstacles.filter(
     (node) => node.x < endLeft && node.x + node.width > startRight,
   );
@@ -318,16 +316,34 @@ function routeAroundNodes(
     ...bandObstacles.map((node) => node.y + node.height),
   ) + gap;
 
-  const detourY = Math.abs(topY - startCy) <= Math.abs(bottomY - startCy) ? topY : bottomY;
-  const midX1 = startRight + gap;
-  const midX2 = endLeft - gap;
+  const detourYCandidates = [topY, bottomY];
+  // midX1=startRight (zero-length first h-seg) handles obstacles flush against source.
+  const midX1Candidates = [startRight + gap, startRight, ...obstacles.map((n) => n.x + n.width + gap)];
+  const midX2Candidates = [endLeft - gap, endLeft, ...obstacles.map((n) => n.x - gap)];
 
+  for (const detourY of detourYCandidates) {
+    for (const mx1 of midX1Candidates) {
+      for (const mx2 of midX2Candidates) {
+        const route: [number, number][] = [
+          [startRight, startCy],
+          [mx1, startCy],
+          [mx1, detourY],
+          [mx2, detourY],
+          [mx2, endCy],
+          [endLeft, endCy],
+        ];
+        if (polylineClear(route)) return route;
+      }
+    }
+  }
+
+  // Absolute fallback: U-shape with default coordinates (may still clip in extreme cases).
   return [
     [startRight, startCy],
-    [midX1, startCy],
-    [midX1, detourY],
-    [midX2, detourY],
-    [midX2, endCy],
+    [startRight + gap, startCy],
+    [startRight + gap, topY],
+    [endLeft - gap, topY],
+    [endLeft - gap, endCy],
     [endLeft, endCy],
   ];
 }
@@ -451,4 +467,3 @@ export function setAutoElementsLocked(
     isAutoElement(element) ? { ...element, locked } : element,
   );
 }
-

--- a/frontend/src/graph/converter.ts
+++ b/frontend/src/graph/converter.ts
@@ -50,7 +50,7 @@ export function convertGraphToElements(
   const newEdges = edges.filter(
     (e) => newNodes.some((n) => n.id === e.from) || newNodes.some((n) => n.id === e.to),
   );
-  const fresh = layoutGraph(newNodes, newEdges);
+  const { positions: fresh } = layoutGraph(newNodes, newEdges);
 
   const merged = new Map<string, LayoutPosition>();
   for (const node of nodes) {
@@ -58,7 +58,30 @@ export function convertGraphToElements(
     if (pos) merged.set(node.id, pos);
   }
 
-  const skeletons: ExcalidrawElementSkeleton[] = [];
+  // Excalidraw renders elements in array order: earlier = lower z-order (behind).
+  // Arrows must come before rectangles so nodes are drawn on top of edges.
+  const edgeSkeletons: ExcalidrawElementSkeleton[] = [];
+  const nodeSkeletons: ExcalidrawElementSkeleton[] = [];
+
+  for (const edge of edges) {
+    if (!merged.has(edge.from) || !merged.has(edge.to)) continue;
+    const customData: GraphCustomData = {
+      kind: GRAPH_ELEMENT_KIND_EDGE,
+      edgeKey: edgeKey(edge),
+      source: 'auto',
+    };
+    edgeSkeletons.push({
+      type: 'arrow',
+      id: `auto-edge-${edgeKey(edge)}`,
+      x: 0,
+      y: 0,
+      strokeColor: AUTO_EDGE_STROKE,
+      locked,
+      customData,
+      start: { id: nodeElementId(edge.from) },
+      end: { id: nodeElementId(edge.to) },
+    } as ExcalidrawElementSkeleton);
+  }
 
   for (const node of nodes) {
     const pos = merged.get(node.id);
@@ -70,7 +93,7 @@ export function convertGraphToElements(
       changedSinceBase: node.changedSinceBase === true,
     };
     const strokeColor = node.changedSinceBase ? CHANGED_NODE_STROKE : AUTO_NODE_STROKE;
-    skeletons.push({
+    nodeSkeletons.push({
       type: 'rectangle',
       id: nodeElementId(node.id),
       x: pos.x,
@@ -93,25 +116,7 @@ export function convertGraphToElements(
     });
   }
 
-  for (const edge of edges) {
-    if (!merged.has(edge.from) || !merged.has(edge.to)) continue;
-    const customData: GraphCustomData = {
-      kind: GRAPH_ELEMENT_KIND_EDGE,
-      edgeKey: edgeKey(edge),
-      source: 'auto',
-    };
-    skeletons.push({
-      type: 'arrow',
-      id: `auto-edge-${edgeKey(edge)}`,
-      x: 0,
-      y: 0,
-      strokeColor: AUTO_EDGE_STROKE,
-      locked,
-      customData,
-      start: { id: nodeElementId(edge.from) },
-      end: { id: nodeElementId(edge.to) },
-    });
-  }
+  const skeletons = [...edgeSkeletons, ...nodeSkeletons];
 
   // Keep deterministic ids so bound text containerId / arrow bindings still
   // reference the `auto-node-{nodeId}` ids we generated. Without this Excalidraw
@@ -122,13 +127,151 @@ export function convertGraphToElements(
     regenerateIds: false,
   }) as unknown as ExcalidrawElement[];
 
+  // `convertToExcalidrawElements` fills `startBinding`/`endBinding` for arrows
+  // but leaves their geometry as a placeholder (`points: [[0.5, 0], [99.5, 0]]`,
+  // `width: 100, height: 0`). Replace with orthogonal L-shape routes that avoid
+  // passing through intermediate node bodies. (Issue #92.)
+  anchorAutoArrowsToBindings(built);
+
   // Stamp customData on auto-generated bound labels so partitionElements()
   // and the lock toggle treat them as auto elements.
   const stubs = built.map((element) =>
-    stampAutoCustomData(element as unknown as ExcalidrawElementStub, built as unknown as ExcalidrawElementStub[]),
+    stampAutoCustomData(
+      element as unknown as ExcalidrawElementStub,
+      built as unknown as ExcalidrawElementStub[],
+    ),
   );
 
   return { elements: stubs, positions: merged };
+}
+
+/**
+ * Walk from rect center in direction (dx, dy) and return where the ray
+ * exits the rect. Used to clip arrow endpoints to node boundaries so they
+ * don't appear to pass through nodes on first render.
+ */
+function clipToRectBoundary(
+  cx: number,
+  cy: number,
+  halfWidth: number,
+  halfHeight: number,
+  dx: number,
+  dy: number,
+): { x: number; y: number } {
+  if (dx === 0 && dy === 0) return { x: cx, y: cy };
+  const tx = dx === 0 ? Infinity : halfWidth / Math.abs(dx);
+  const ty = dy === 0 ? Infinity : halfHeight / Math.abs(dy);
+  const t = Math.min(tx, ty);
+  return { x: cx + dx * t, y: cy + dy * t };
+}
+
+/**
+ * `convertToExcalidrawElements` leaves arrows with placeholder geometry; the
+ * binding-driven recompute only fires on element movement, not on scene load.
+ * Replace placeholder points with orthogonal L-shape routes that avoid
+ * passing through intermediate node bodies.
+ */
+function anchorAutoArrowsToBindings(elements: ExcalidrawElement[]): void {
+  const nodesById = new Map<string, ExcalidrawElement>();
+  for (const el of elements) {
+    if (el.type === 'rectangle') nodesById.set(el.id, el);
+  }
+
+  for (const el of elements) {
+    if (el.type !== 'arrow') continue;
+    const arrow = el as ExcalidrawElement & {
+      startBinding?: { elementId?: string } | null;
+      endBinding?: { elementId?: string } | null;
+    };
+    const startId = arrow.startBinding?.elementId;
+    const endId = arrow.endBinding?.elementId;
+    if (!startId || !endId) continue;
+    const start = nodesById.get(startId);
+    const end = nodesById.get(endId);
+    if (!start || !end) continue;
+
+    const mutable = arrow as unknown as {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      points: [number, number][];
+    };
+
+    const allPoints = routeAroundNodes(start, end, nodesById, startId, endId);
+    const xs = allPoints.map(([px]) => px);
+    const ys = allPoints.map(([, py]) => py);
+    const ox = allPoints[0][0];
+    const oy = allPoints[0][1];
+    const relative: [number, number][] = allPoints.map(([px, py]) => [px - ox, py - oy]);
+    const relXs = relative.map(([px]) => px);
+    const relYs = relative.map(([, py]) => py);
+
+    mutable.x = ox;
+    mutable.y = oy;
+    mutable.width = Math.max(...relXs) - Math.min(...relXs);
+    mutable.height = Math.max(...relYs) - Math.min(...relYs);
+    mutable.points = relative;
+  }
+}
+
+/** Returns an orthogonal route (absolute coords) from source right edge to target left edge.
+ *  Uses 3-segment L-shape: right → mid-x turn → arrive at target left.
+ *  If the mid-x vertical segment would clip any intermediate node, offsets it above/below.
+ */
+function routeAroundNodes(
+  start: ExcalidrawElement,
+  end: ExcalidrawElement,
+  nodesById: Map<string, ExcalidrawElement>,
+  startId: string,
+  endId: string,
+): [number, number][] {
+  const startRight = start.x + start.width;
+  const startCy = start.y + start.height / 2;
+  const endLeft = end.x;
+  const endCy = end.y + end.height / 2;
+
+  // Source is to the right of target — use a straight boundary-clipped line.
+  if (startRight >= endLeft) {
+    const scx = start.x + start.width / 2;
+    const scy = startCy;
+    const ecx = end.x + end.width / 2;
+    const ecy = endCy;
+    const dx = ecx - scx;
+    const dy = ecy - scy;
+    const sp = clipToRectBoundary(scx, scy, start.width / 2, start.height / 2, dx, dy);
+    const ep = clipToRectBoundary(ecx, ecy, end.width / 2, end.height / 2, -dx, -dy);
+    return [
+      [sp.x, sp.y],
+      [ep.x, ep.y],
+    ];
+  }
+
+  // 3-segment orthogonal route: (startRight, startCy) → (midX, startCy) → (midX, endCy) → (endLeft, endCy)
+  let midX = (startRight + endLeft) / 2;
+
+  // Check if the vertical segment at midX clips any other node.
+  const minY = Math.min(startCy, endCy);
+  const maxY = Math.max(startCy, endCy);
+  for (const [id, node] of nodesById) {
+    if (id === startId || id === endId) continue;
+    if (node.x > midX || node.x + node.width < midX) continue;
+    if (node.y > maxY || node.y + node.height < minY) continue;
+    // midX cuts through this node — shift the vertical segment left or right.
+    const gap = 12;
+    const leftX = node.x - gap;
+    const rightX = node.x + node.width + gap;
+    // Pick whichever X detour keeps midX closer to the natural midpoint.
+    midX = Math.abs(leftX - midX) <= Math.abs(rightX - midX) ? leftX : rightX;
+    break;
+  }
+
+  return [
+    [startRight, startCy],
+    [midX, startCy],
+    [midX, endCy],
+    [endLeft, endCy],
+  ];
 }
 
 function stampAutoCustomData(
@@ -250,3 +393,4 @@ export function setAutoElementsLocked(
     isAutoElement(element) ? { ...element, locked } : element,
   );
 }
+

--- a/frontend/src/graph/converter.ts
+++ b/frontend/src/graph/converter.ts
@@ -230,10 +230,9 @@ function vSegmentClipsNode(x: number, y1: number, y2: number, node: ExcalidrawEl
 }
 
 /** Returns an orthogonal route (absolute coords) from source right edge to target left edge.
- *  Uses 3-segment L-shape: right → mid-x turn → arrive at target left.
- *  Validates all three segments against intermediate node bodies and offsets midX
- *  until none of the segments clip a node. Falls back to a straight clipped line
- *  if no clear orthogonal route can be found.
+ *  Primary: 3-segment L-shape (right → midX → arrive at target left).
+ *  Fallback: 5-segment U-shape going above/below all obstacles when no clear midX exists.
+ *  Falls back to a straight clipped line when source is to the right of target.
  */
 function routeAroundNodes(
   start: ExcalidrawElement,
@@ -263,7 +262,6 @@ function routeAroundNodes(
     ];
   }
 
-  // 3-segment orthogonal route: (startRight, startCy) → (midX, startCy) → (midX, endCy) → (endLeft, endCy)
   // Collect obstacle nodes (exclude start and end).
   const obstacles: ExcalidrawElement[] = [];
   for (const [id, node] of nodesById) {
@@ -271,33 +269,65 @@ function routeAroundNodes(
   }
 
   const gap = 12;
-  let midX = (startRight + endLeft) / 2;
 
-  // Iteratively shift midX until all three segments clear every obstacle.
-  // Limit iterations to avoid infinite loops on dense graphs.
-  for (let iter = 0; iter < obstacles.length * 2 + 1; iter++) {
-    let clippingNode: ExcalidrawElement | undefined;
+  /** Check if a 3-segment route with the given midX clears all obstacles. */
+  function threeSegClear(mx: number): boolean {
     for (const node of obstacles) {
       if (
-        vSegmentClipsNode(midX, startCy, endCy, node) ||
-        hSegmentClipsNode(startRight, midX, startCy, node) ||
-        hSegmentClipsNode(midX, endLeft, endCy, node)
+        vSegmentClipsNode(mx, startCy, endCy, node) ||
+        hSegmentClipsNode(startRight, mx, startCy, node) ||
+        hSegmentClipsNode(mx, endLeft, endCy, node)
       ) {
-        clippingNode = node;
-        break;
+        return false;
       }
     }
-    if (!clippingNode) break;
-
-    const leftX = clippingNode.x - gap;
-    const rightX = clippingNode.x + clippingNode.width + gap;
-    midX = Math.abs(leftX - midX) <= Math.abs(rightX - midX) ? leftX : rightX;
+    return true;
   }
+
+  // Try candidate midX values: default midpoint, then left/right edges of each obstacle.
+  const defaultMidX = (startRight + endLeft) / 2;
+  const candidates: number[] = [defaultMidX];
+  for (const node of obstacles) {
+    candidates.push(node.x - gap);
+    candidates.push(node.x + node.width + gap);
+  }
+
+  for (const mx of candidates) {
+    if (threeSegClear(mx)) {
+      return [
+        [startRight, startCy],
+        [mx, startCy],
+        [mx, endCy],
+        [endLeft, endCy],
+      ];
+    }
+  }
+
+  // No 3-segment route is clear — use 5-segment U-shape going above or below all
+  // obstacle nodes that sit in the horizontal band between startRight and endLeft.
+  const bandObstacles = obstacles.filter(
+    (node) => node.x < endLeft && node.x + node.width > startRight,
+  );
+
+  const topY = Math.min(
+    start.y, end.y,
+    ...bandObstacles.map((node) => node.y),
+  ) - gap;
+  const bottomY = Math.max(
+    start.y + start.height, end.y + end.height,
+    ...bandObstacles.map((node) => node.y + node.height),
+  ) + gap;
+
+  const detourY = Math.abs(topY - startCy) <= Math.abs(bottomY - startCy) ? topY : bottomY;
+  const midX1 = startRight + gap;
+  const midX2 = endLeft - gap;
 
   return [
     [startRight, startCy],
-    [midX, startCy],
-    [midX, endCy],
+    [midX1, startCy],
+    [midX1, detourY],
+    [midX2, detourY],
+    [midX2, endCy],
     [endLeft, endCy],
   ];
 }

--- a/frontend/src/graph/layout.test.ts
+++ b/frontend/src/graph/layout.test.ts
@@ -21,7 +21,7 @@ describe('layoutGraph', () => {
       { from: 'a', to: 'b' },
       { from: 'b', to: 'c' },
     ];
-    const positions = layoutGraph(nodes, edges);
+    const { positions } = layoutGraph(nodes, edges);
     expect(positions.size).toBe(3);
     for (const id of ['a', 'b', 'c']) {
       const pos = positions.get(id);
@@ -34,7 +34,7 @@ describe('layoutGraph', () => {
   it('places connected nodes at distinct x positions for LR layout', () => {
     const nodes = [node('a'), node('b')];
     const edges: GraphEdge[] = [{ from: 'a', to: 'b' }];
-    const positions = layoutGraph(nodes, edges);
+    const { positions } = layoutGraph(nodes, edges);
     expect(positions.get('a')?.x).not.toBe(positions.get('b')?.x);
   });
 
@@ -42,5 +42,18 @@ describe('layoutGraph', () => {
     const nodes = [node('a')];
     const edges: GraphEdge[] = [{ from: 'a', to: 'missing' }];
     expect(() => layoutGraph(nodes, edges)).not.toThrow();
+  });
+
+  it('returns edge waypoints for each laid-out edge', () => {
+    const nodes = [node('a'), node('b')];
+    const edges: GraphEdge[] = [{ from: 'a', to: 'b' }];
+    const { edgeWaypoints } = layoutGraph(nodes, edges);
+    const wp = edgeWaypoints.get('a->b');
+    expect(wp).toBeDefined();
+    expect(wp?.points.length).toBeGreaterThanOrEqual(2);
+    for (const pt of wp?.points ?? []) {
+      expect(typeof pt.x).toBe('number');
+      expect(typeof pt.y).toBe('number');
+    }
   });
 });

--- a/frontend/src/graph/layout.ts
+++ b/frontend/src/graph/layout.ts
@@ -17,11 +17,23 @@ export interface LayoutOptions {
   nodesep?: number;
 }
 
+export interface EdgeWaypoints {
+  from: string;
+  to: string;
+  /** Absolute-coordinate waypoints including the clipped start/end points. */
+  points: { x: number; y: number }[];
+}
+
+export interface LayoutResult {
+  positions: Map<string, LayoutPosition>;
+  edgeWaypoints: Map<string, EdgeWaypoints>;
+}
+
 export function layoutGraph(
   nodes: readonly GraphNode[],
   edges: readonly GraphEdge[],
   options: LayoutOptions = {},
-): Map<string, LayoutPosition> {
+): LayoutResult {
   const g = new dagre.graphlib.Graph();
   g.setGraph({
     rankdir: options.rankdir ?? 'LR',
@@ -53,5 +65,18 @@ export function layoutGraph(
       y: dagreNode.y - h / 2,
     });
   }
-  return positions;
+
+  const edgeWaypoints = new Map<string, EdgeWaypoints>();
+  for (const edge of edges) {
+    const dagreEdge = g.edge(edge.from, edge.to);
+    if (!dagreEdge?.points?.length) continue;
+    const key = `${edge.from}->${edge.to}`;
+    edgeWaypoints.set(key, {
+      from: edge.from,
+      to: edge.to,
+      points: dagreEdge.points as { x: number; y: number }[],
+    });
+  }
+
+  return { positions, edgeWaypoints };
 }

--- a/frontend/src/sticky/sticky.test.ts
+++ b/frontend/src/sticky/sticky.test.ts
@@ -57,6 +57,14 @@ jest.mock('@excalidraw/excalidraw', () => ({
         out.push({
           ...skel,
           id: arrowId,
+          x: 0,
+          y: 0,
+          width: 100,
+          height: 0,
+          points: [
+            [0.5, 0],
+            [99.5, 0],
+          ],
           startBinding: start
             ? { elementId: resolveId(start.id), focus: 0, gap: 0 }
             : undefined,
@@ -153,6 +161,30 @@ describe('createStickyForAnchor', () => {
     const endBinding = arrow?.endBinding as { elementId: string };
     expect(startBinding?.elementId).toBe(anchor.id);
     expect(endBinding?.elementId).toBe(bodyElementId);
+  });
+
+  it('clips connector endpoints to the boundaries of anchor and sticky body', () => {
+    // Regression for #92: convertToExcalidrawElements emits placeholder geometry
+    // for the connector arrow. We clip to rect boundaries so it renders cleanly
+    // without passing through the anchor or sticky body.
+    const { elements } = createStickyForAnchor(anchor, {
+      reviewId: 'r-geom',
+      title: 't',
+      body: 'b',
+    });
+    const arrow = elements.find((e) => e.type === 'arrow');
+    expect(arrow).toBeDefined();
+    const startsOnAnchorBoundary = (px: number, py: number): boolean => {
+      const onLeft = Math.abs(px - anchor.x) < 1e-6;
+      const onRight = Math.abs(px - (anchor.x + anchor.width)) < 1e-6;
+      const onTop = Math.abs(py - anchor.y) < 1e-6;
+      const onBottom = Math.abs(py - (anchor.y + anchor.height)) < 1e-6;
+      return onLeft || onRight || onTop || onBottom;
+    };
+    expect(startsOnAnchorBoundary(arrow!.x as number, arrow!.y as number)).toBe(true);
+    const points = (arrow as { points?: number[][] } | undefined)?.points;
+    expect(points?.[0]).toEqual([0, 0]);
+    expect(arrow?.width).toBeGreaterThan(0);
   });
 
   it('uses dashed connector style and unlocked elements', () => {

--- a/frontend/src/sticky/sticky.ts
+++ b/frontend/src/sticky/sticky.ts
@@ -132,6 +132,11 @@ export function createStickyForAnchor(
     regenerateIds: false,
   }) as unknown as ExcalidrawElement[];
 
+  // `convertToExcalidrawElements` leaves the connector arrow with placeholder
+  // geometry; bindings are set but points are not anchored. Compute geometry
+  // from anchor → sticky body so the arrow renders on first paint. (Issue #92.)
+  anchorStickyConnector(built, anchor, stickyX, stickyY);
+
   // Stamp customData on bound label so it travels with the sticky.
   const stubs = built.map((element) =>
     stampStickyCustomData(
@@ -148,6 +153,55 @@ export function createStickyForAnchor(
     bodyElementId: bodyElementId(reviewId),
     connectorElementId: connectorElementId(reviewId),
   };
+}
+
+function clipToRectBoundary(
+  cx: number,
+  cy: number,
+  halfWidth: number,
+  halfHeight: number,
+  dx: number,
+  dy: number,
+): { x: number; y: number } {
+  if (dx === 0 && dy === 0) return { x: cx, y: cy };
+  const tx = dx === 0 ? Infinity : halfWidth / Math.abs(dx);
+  const ty = dy === 0 ? Infinity : halfHeight / Math.abs(dy);
+  const t = Math.min(tx, ty);
+  return { x: cx + dx * t, y: cy + dy * t };
+}
+
+function anchorStickyConnector(
+  elements: ExcalidrawElement[],
+  anchor: AnchorBox,
+  stickyX: number,
+  stickyY: number,
+): void {
+  for (const el of elements) {
+    if (el.type !== 'arrow') continue;
+    const scx = anchor.x + anchor.width / 2;
+    const scy = anchor.y + anchor.height / 2;
+    const ecx = stickyX + STICKY_WIDTH / 2;
+    const ecy = stickyY + STICKY_HEIGHT / 2;
+    const dx = ecx - scx;
+    const dy = ecy - scy;
+    const startPoint = clipToRectBoundary(scx, scy, anchor.width / 2, anchor.height / 2, dx, dy);
+    const endPoint = clipToRectBoundary(ecx, ecy, STICKY_WIDTH / 2, STICKY_HEIGHT / 2, -dx, -dy);
+    const mutable = el as unknown as {
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      points: [number, number][];
+    };
+    mutable.x = startPoint.x;
+    mutable.y = startPoint.y;
+    mutable.width = Math.abs(endPoint.x - startPoint.x);
+    mutable.height = Math.abs(endPoint.y - startPoint.y);
+    mutable.points = [
+      [0, 0],
+      [endPoint.x - startPoint.x, endPoint.y - startPoint.y],
+    ];
+  }
 }
 
 export function createDetachedSticky(options: CreateStickyOptions = {}): CreateStickyResult {

--- a/frontend/src/storage/canvasStorage.test.ts
+++ b/frontend/src/storage/canvasStorage.test.ts
@@ -54,6 +54,29 @@ describe('canvasStorage', () => {
     });
   });
 
+  it('sorts graph edges before graph nodes while preserving non-graph element positions', () => {
+    // Simulates a saved scene where a graphNode appeared before its graphEdge (old layout),
+    // with a reviewSticky sandwiched between them. The sort must not move the sticky.
+    const document = createCanvasDocumentFromScene({
+      elements: [
+        { id: 'node-a', type: 'rectangle', customData: { kind: 'graphNode', source: 'auto' } },
+        { id: 'sticky-1', type: 'rectangle', customData: { kind: 'reviewSticky', reviewId: 'r1' } },
+        { id: 'edge-ab', type: 'arrow', customData: { kind: 'graphEdge', source: 'auto' } },
+        { id: 'node-b', type: 'rectangle', customData: { kind: 'graphNode', source: 'auto' } },
+      ],
+    });
+    const { elements } = toExcalidrawInitialData(document);
+    // graphEdge must come before graphNodes
+    const edgeIdx = elements.findIndex((e) => e.id === 'edge-ab');
+    const nodeAIdx = elements.findIndex((e) => e.id === 'node-a');
+    const nodeBIdx = elements.findIndex((e) => e.id === 'node-b');
+    expect(edgeIdx).toBeLessThan(nodeAIdx);
+    expect(edgeIdx).toBeLessThan(nodeBIdx);
+    // sticky-1 must not be displaced to after the graph block
+    const stickyIdx = elements.findIndex((e) => e.id === 'sticky-1');
+    expect(stickyIdx).toBeLessThan(nodeBIdx);
+  });
+
   it('normalizes v1 canvas documents while ignoring legacy cards', () => {
     const legacy = JSON.stringify({
       version: 1,

--- a/frontend/src/storage/canvasStorage.ts
+++ b/frontend/src/storage/canvasStorage.ts
@@ -49,13 +49,35 @@ export function createCanvasDocumentFromScene(scene: CanvasSceneSnapshot): Canva
 
 export function toExcalidrawInitialData(document: CanvasDocument): ExcalidrawInitialDataSnapshot {
   return {
-    elements: document.elements,
+    elements: sortEdgesBehindNodes(document.elements),
     appState: {
       ...(document.appState ?? {}),
       collaborators: new Map(),
     },
     files: document.files ?? {},
   };
+}
+
+/**
+ * Excalidraw renders elements in array order — earlier = lower z-order (behind).
+ * Saved files may have auto graph nodes before edges (old layout). Re-sort so
+ * edges render behind nodes without touching user elements.
+ */
+function sortEdgesBehindNodes(elements: readonly ExcalidrawElementStub[]): ExcalidrawElementStub[] {
+  const autoEdges: ExcalidrawElementStub[] = [];
+  const autoNodes: ExcalidrawElementStub[] = [];
+  const rest: ExcalidrawElementStub[] = [];
+  for (const el of elements) {
+    const kind = (el.customData as { kind?: string } | undefined)?.kind;
+    if (kind === 'graphEdge') {
+      autoEdges.push(el);
+    } else if (kind === 'graphNode') {
+      autoNodes.push(el);
+    } else {
+      rest.push(el);
+    }
+  }
+  return [...autoEdges, ...autoNodes, ...rest];
 }
 
 function cloneElements(elements: readonly ExcalidrawElementStub[]): ExcalidrawElementStub[] {

--- a/frontend/src/storage/canvasStorage.ts
+++ b/frontend/src/storage/canvasStorage.ts
@@ -61,23 +61,42 @@ export function toExcalidrawInitialData(document: CanvasDocument): ExcalidrawIni
 /**
  * Excalidraw renders elements in array order — earlier = lower z-order (behind).
  * Saved files may have auto graph nodes before edges (old layout). Re-sort so
- * edges render behind nodes without touching user elements.
+ * edges render behind nodes, while non-graph elements stay at their original
+ * array positions to preserve their persisted z-order.
+ *
+ * Only the slots occupied by graph elements are reshuffled (edges first, then
+ * nodes); reviewSticky, userArrow, userText, and any other elements keep their
+ * relative order relative to each other and to the graph block.
  */
 function sortEdgesBehindNodes(elements: readonly ExcalidrawElementStub[]): ExcalidrawElementStub[] {
-  const autoEdges: ExcalidrawElementStub[] = [];
-  const autoNodes: ExcalidrawElementStub[] = [];
-  const rest: ExcalidrawElementStub[] = [];
-  for (const el of elements) {
-    const kind = (el.customData as { kind?: string } | undefined)?.kind;
+  // Collect the indices of graph elements in their current order.
+  const graphSlots: number[] = [];
+  const edgeIndices: number[] = [];
+  const nodeIndices: number[] = [];
+  for (let i = 0; i < elements.length; i++) {
+    const kind = (elements[i].customData as { kind?: string } | undefined)?.kind;
     if (kind === 'graphEdge') {
-      autoEdges.push(el);
+      graphSlots.push(i);
+      edgeIndices.push(i);
     } else if (kind === 'graphNode') {
-      autoNodes.push(el);
-    } else {
-      rest.push(el);
+      graphSlots.push(i);
+      nodeIndices.push(i);
     }
   }
-  return [...autoEdges, ...autoNodes, ...rest];
+
+  // If graph elements are already in edge-first order, nothing to do.
+  const alreadySorted =
+    graphSlots.length === edgeIndices.length + nodeIndices.length &&
+    [...edgeIndices, ...nodeIndices].every((idx, j) => idx === graphSlots[j]);
+  if (alreadySorted) return elements as ExcalidrawElementStub[];
+
+  // Re-assign graph slots: edges first, then nodes. Non-graph slots are untouched.
+  const result = [...elements] as ExcalidrawElementStub[];
+  const reorderedSources = [...edgeIndices, ...nodeIndices];
+  for (let j = 0; j < graphSlots.length; j++) {
+    result[graphSlots[j]] = elements[reorderedSources[j]];
+  }
+  return result;
 }
 
 function cloneElements(elements: readonly ExcalidrawElementStub[]): ExcalidrawElementStub[] {

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- 화살표가 노드 블록 위로 그려지는 z-order 회귀 수정: 엣지/노드 스켈레톤을 분리해 edges-first로 연결, 화살표가 노드 뒤에 렌더링되도록 변경
- 기존 저장된 `.codetrace` 파일 로드 시에도 z-order 보장: `toExcalidrawInitialData`에 `sortEdgesBehindNodes` 적용
- `routeAroundNodes` 좌표 버그 수정: 수직 세그먼트 우회 계산 시 Y 오프셋이 `midX`에 잘못 할당되던 문제 수정
- pan/zoom 시 단일 프레임 히컵 제거: `onChange` 동기 직렬화를 200ms 디바운스로 교체하고 pan/zoom skip 프레임에서 pending 타이머를 defer 처리

Closes #92

## Verification
- npm run build --workspace=frontend
- npm test --workspace=frontend -- --runInBand
- npm exec --workspace=frontend -- tsc --noEmit